### PR TITLE
fix typo of ./sign can that should be ./update

### DIFF
--- a/w3-account.md
+++ b/w3-account.md
@@ -225,7 +225,7 @@ Issued by an agent on behalf of an account to the service as a request for all v
      aud: "did:mailto:alice@web.mail",
      att: [{
        with: "did:web:web3.storage",
-       can: "./sign",
+       can: "./update",
        nb: { key: "did:key:zAgent" }
      }],
      exp: null


### PR DESCRIPTION
Motivation:
* resolve https://github.com/web3-storage/specs/issues/29
* I asked @Gozala via slack and he confirmed that `./sign` was from old versions, and this is meant to be `./update` (defined above in doc)