### PR TITLE
feat: update docs with new `pre` caveat for `store/list` and `upload/list`

### DIFF
--- a/w3-store.md
+++ b/w3-store.md
@@ -406,7 +406,6 @@ When invoking `upload/list` the `size` caveat may be set to the desired number o
 | `cursor` | `string`                          |             | An opaque string included in a prior `store/list` response that allows the service to provide the next "page" of results. |
 | `pre`    | `boolean`                         |             | If true, return the page of results preceeding the cursor.                                                                |
 
-
 #### Invocation
 
 ```js

--- a/w3-store.md
+++ b/w3-store.md
@@ -203,8 +203,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 #### Caveats
 
-When invoking `store/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre`
-caveat may be set to return the page of results preceeding the cursor.
+When invoking `store/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre` caveat may be set to return the page of results preceeding the cursor.
 
 | `field`  | `value`                           | `required?` | `context`                                                                                                                 |
 | -------- | --------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -399,8 +398,7 @@ The `upload/list` capability can be invoked to request a list of metadata about 
 
 #### Caveats
 
-When invoking `upload/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre`
-caveat may be set to return the page of results preceeding the cursor.
+When invoking `upload/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre` caveat may be set to return the page of results preceeding the cursor.
 
 | `field`  | `value`                           | `required?` | `context`                                                                                                                 |
 | -------- | --------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |

--- a/w3-store.md
+++ b/w3-store.md
@@ -203,13 +203,13 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 #### Caveats
 
-When invoking `store/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre` caveat may be set to return the page of results preceeding the cursor.
+When invoking `store/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre` caveat may be set to return the page of results preceding the cursor.
 
 | `field`  | `value`                           | `required?` | `context`                                                                                                                 |
 | -------- | --------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `size`   | `number`                          |             | The desired number of results to return.                                                                                  |
 | `cursor` | `string`                          |             | An opaque string included in a prior `store/list` response that allows the service to provide the next "page" of results. |
-| `pre`    | `boolean`                         |             | If true, return the page of results preceeding the cursor.                                                                |
+| `pre`    | `boolean`                         |             | If true, return the page of results preceding the cursor.                                                                |
 
 #### Invocation
 
@@ -398,13 +398,13 @@ The `upload/list` capability can be invoked to request a list of metadata about 
 
 #### Caveats
 
-When invoking `upload/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre` caveat may be set to return the page of results preceeding the cursor.
+When invoking `upload/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre` caveat may be set to return the page of results preceding the cursor.
 
 | `field`  | `value`                           | `required?` | `context`                                                                                                                 |
 | -------- | --------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `size`   | `number`                          |             | The desired number of results to return.                                                                                  |
 | `cursor` | `string`                          |             | An opaque string included in a prior `store/list` response that allows the service to provide the next "page" of results. |
-| `pre`    | `boolean`                         |             | If true, return the page of results preceeding the cursor.                                                                |
+| `pre`    | `boolean`                         |             | If true, return the page of results preceding the cursor.                                                                |
 
 #### Invocation
 

--- a/w3-store.md
+++ b/w3-store.md
@@ -203,12 +203,14 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 #### Caveats
 
-When invoking `store/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response.
+When invoking `store/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre`
+caveat may be set to return the page of results preceeding the cursor.
 
 | `field`  | `value`                           | `required?` | `context`                                                                                                                 |
 | -------- | --------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `size`   | `number`                          |             | The desired number of results to return.                                                                                  |
 | `cursor` | `string`                          |             | An opaque string included in a prior `store/list` response that allows the service to provide the next "page" of results. |
+| `pre`    | `boolean`                         |             | If true, return the page of results preceeding the cursor.                                                                |
 
 #### Invocation
 
@@ -397,12 +399,15 @@ The `upload/list` capability can be invoked to request a list of metadata about 
 
 #### Caveats
 
-When invoking `upload/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response.
+When invoking `upload/list` the `size` caveat may be set to the desired number of results to return per invocation. If there are more total results than will fit into the given `size`, the response will include an opaque `cursor` field that can be used to continue the listing in a subsequent invocation by setting the `cursor` caveat to the value in the response. The `pre`
+caveat may be set to return the page of results preceeding the cursor.
 
 | `field`  | `value`                           | `required?` | `context`                                                                                                                 |
 | -------- | --------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `size`   | `number`                          |             | The desired number of results to return.                                                                                  |
 | `cursor` | `string`                          |             | An opaque string included in a prior `store/list` response that allows the service to provide the next "page" of results. |
+| `pre`    | `boolean`                         |             | If true, return the page of results preceeding the cursor.                                                                |
+
 
 #### Invocation
 


### PR DESCRIPTION
sync with the work merged in https://github.com/web3-storage/w3protocol/pull/423