### PR TITLE
Feat/auth+account

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -85,3 +85,12 @@ AgentPrincipal
 implementers
 DomainKeys
 DKIM
+RFC6376
+UTF-8
+UCAN-IPLD
+DAG-JSON
+installationOraclePrincipal
+flowAuthorityPrincipal
+capabilitiesVerifierComponent
+Verifier
+sudo

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -56,8 +56,6 @@ namespace
 namespaces
 UnixFS
 repo
-
-# actually correct
 reimagine
 invocable
 roundtrip
@@ -73,11 +71,17 @@ validSession
 keyThe
 DKIM-Signature
 ABNF
-
-# wut
 HeaderTypeDescriptionRequiredCardinalityEntrypoint
 UCANNoZero
 UCANYesOneMapping
 HeaderTypeDescriptionRequiredCardinalityEntry
 OperationCapabilities
 5GiB
+w3
+PKI
+onboarding
+NameDescriptionAccountPrincipal
+AgentPrincipal
+implementers
+DomainKeys
+DKIM

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -72,6 +72,7 @@ AuthorityAn
 validSession
 keyThe
 DKIM-Signature
+ABNF
 
 # wut
 HeaderTypeDescriptionRequiredCardinalityEntrypoint

--- a/w3-account.md
+++ b/w3-account.md
@@ -1,0 +1,193 @@
+# Account
+
+![status:wip](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square)
+
+## Editors
+
+- [Irakli Gozalishvili], [Protocol Labs]
+
+## Authors
+
+- [Irakli Gozalishvili], [Protocol Labs]
+
+# Abstract
+
+In w3 family of open protocols users interact with self-certified ([PKI] baked) namespaces. Access to such namespaces is managed through delegated [UCAN] capabilities that need to be synced across multiple user agents on multiple devices. Doing this in an open and decentralized system introduces unique UX challenges that we attempt to address through a concept of an **account** as described by this specification.
+
+## Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+# Introduction
+
+In web3 namespace is simply [`did:key`] identifier. As a result, [principal] identified by the [`did:key`] is an owner of that namespace with a absolute authority over it. It can delegate some or all of the capabilities for the resources under that namespace to any other [principal]. However managing delegations across various user agents has several UX challenges:
+
+1. Syncing delegations to namespace(s) across multiple user agents on multiple devices introduces discovery problem, challenged by use of not memorable [`did:key`] identifiers.
+2. Recovering access in case where user loses access to all of the devices.
+
+We propose concept of an account as convenience for aggregating and managing capabilities under human-meaningful identifier like an email address. More specifically we propose deriving account [`did:mailto`] identifier from user controlled email address, so it can act as [principal] in [UCAN] delegation chains.
+
+User can aggregate all delegations under such an account identifier and re-delegate desired capabilities to other agents. Use of memorable identifier addresses discovery problem. Furthermore email address as an account provides smooth web3 onboarding experience by hiding all of the [PKI] under familiar email based authorization flows.
+
+> ℹ️ This specification is focuses on [`did:mailto`] identifiers, however approach can easily be extended to various other identifiers.
+
+# High-Level Concepts
+
+## Roles
+
+There are several distinct roles that [principals] may assume in described specification:
+
+| Name        | Description                                                                                                                                    |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Account    | [Principal] identified by memorable identifier like [`did:mailto`]. |
+| Agent       | [Principal] identified by [`did:key`] identifier, representing a user in some application installation |
+
+### Account
+
+_Account_ is a [principal] identified by a memorable identifier like [`did:mailto`].
+
+Account MAY be used for convenience of aggregating and managing capabilities across various user [Agent]s.
+
+Account CAN be used to facilitate familiar user authorization and recovery flows.
+
+### Agent
+
+_Agent_ is a [principal] identified by a [`did:key`] identifier.
+
+Users interacts with a system through different _agents_ across multiple devices and applications. It is highly RECOMMENDED that _agents_ use [non-extractable keys] when possible.
+
+> ℹ️ _Agents_ are meant to be ephemeral that could be disposed or created on demand.
+
+# Protocol
+
+## Overview
+
+### Aggregating capabilities
+
+Any [`did:key`] identified [agent] CAN (re)delegate capabilities to [`did:mailto`] identified [account] per [UCAN] specification. This MAY be used to delegate complete authority over created namespace on creation.
+
+```mermaid
+sequenceDiagram
+actor Alice
+participant W3 as 💻<br/><br/>web3.storage #32;
+participant Space as 📦<br/><br/>did:key:z6Mkk…sxALi
+participant Email as 📫 alice@web.mail
+
+
+W3 -->> Alice: What is your email ?
+Alice -->> W3: alice@web.mail
+W3->>Space:🔑 Create namespace
+
+Space ->> Email: 🎫 Delegate capabilities
+note over Space,Email:can:*<br/>with: ucan:/*
+```
+
+> On first run new namespace is generated and complete authority is delegated to the user account
+
+Any user CAN (re)delegate capabilities to their peer by delegating to their [`did:mailto`] identified [account] _(which can be derived from the email address)_. Also note that no setup is required from delegate until they decide to invoke delegated capability.
+
+```mermaid
+sequenceDiagram
+participant Alice as 👩‍💻<br/><br/>did:key:z6Mkk…sxALi
+participant Email as 📫 bob@gmail.com
+participant Bob as 👨🏽‍💻 <br/><br/>did:key:z6Mkr…jnz2z
+
+
+Alice ->> Email: 🎫 Delegate capabilities
+note over Alice,Bob:<br/>with: space://z6Mkr…jnz2z<br/>can:store/add
+Email ->> Bob: 🎫 Delegate capabilities
+```
+
+> **Alice** delegates `store/add` capability to **Bob**, who later creates an agent and re-delegates capability to it.
+
+### Delegating capabilities
+
+Delegating capabilities from [`did:mailto`] identified [account] to an [agent] is less straightforward, because signing key is not self-evident from the delegation.
+
+Here we propose extension to the [UCAN] specification to allow signing and verification of [`did:mailto`] issued delegations without requiring a [`did:mailto`] key resolution.
+
+We define two alternative signature types with a different tradeoffs. Protocol implementer MAY support either or both signature types.
+
+> ℹ️ Signatures for [account]s identified by other DID methods is left undefined.
+
+#### DomainKeys Identified Mail (DKIM) Signature
+
+Delegation issued by an [account] identified with [`did:mailto`] identifier MAY be signed using DKIM-Signature DomainKeys Identified Mail ([DKIM]) Signature.
+
+Signature MUST be generated by sending a message from the email address of the [account] with a `Subject` header set to an [authorization payload].
+
+Signer MUST derive "DKIM payload" from the received message per [RFC6376] specification and encode it in UTF-8 encoding. Resulting bytes MUST be encoded as a [Nonstandard `VarSig` signature] with `DKIM` string as an `alg` parameter.
+
+##### Authorization Payload
+
+> ℹ️ Using UCAN standard signing payload would result in a large signatures, which is why we define an alternative payload format.
+
+UCAN data model MUST be structured according to [UCAN-IPLD Schema] omitting `s` field. IPLD [link] of the data model must be derived and formatted according to following [ABNF] definition, where `cid` refers to derived link.
+
+```abnf
+auth := "I am signing ipfs://" cid "to grant access to this account"
+cid  := z[a-km-zA-HJ-NP-Z1-9]+
+```
+
+#### Authorization Session Signature
+
+Delegation issued by an [account] identified with [`did:mailto`] identifier MAY use _authorization session_ signature in conjunction with an [authorization session] (issued by trusted [authority]). If delegation has a proof with such signature, it MUST also have a qualified [authorization session]. If authorization session is not present in the proofs validator MUST carry out an out-of-bound authorization flow to obtain [authorization session] on demand. If validator is unable to carry out authorization flow, it MUST consider signature invalid.
+
+##### Authorization Session Signature Format
+
+The [Nonstandard `VarSig` signature] with `0` bytes MUST be used.
+This type of signature is encoded as a "NonStandard" [VarSig] with 0 bytes, which is shown in [DAG-JSON] format below
+
+##### Authorization Session Signature Example
+
+> Authorization Session Signature in [DAG-JSON] format
+
+```jSON
+{ "/": { "bytes": "gKADAA" } }
+```
+
+### Signup
+
+### Authorization
+
+> On first run **w3.app** request `store/*` capability from **alice@web.mail** through **web3.storage**, which performs out of bound email authorization and delegates granted capability.
+
+```mermaid
+sequenceDiagram
+actor Alice
+participant App as 💻 w3.app
+participant W3 as 🌐<br/><br/>did:web:web3.storage #32;
+participant Email as 📫 alice@web.mail
+
+
+App -->> Alice: What is your email ?
+Alice -->> App: alice@web.mail
+App ->> W3: Can I store/* ❓
+W3 -->> Email: Can w3.app store/* ❓
+note over W3,Email: space://z6Mkk…sxALi<br/>can: store/*<br/>#32;<br/>space://z6Mk…n9bob<br/>can: store/*
+
+
+Email -->> W3: ✉️ grant
+note over Email,W3:with: space://z6Mkk…sxALi<br/>can: store/*
+W3 ->> App: 🎫 delegate
+Note over W3,App:with: space://z6Mkk…sxALi<br/>can:store/*
+```
+
+[Protocol Labs]:https://protocol.ai/
+[Irakli Gozalishvili]:https://github.com/Gozala
+[PKI]:https://en.wikipedia.org/wiki/Public_key_infrastructure
+[ucan]: https://github.com/ucan-wg/spec/
+[`did:mailto`]: https://github.com/ucan-wg/did-mailto/
+[`did:key`]: https://w3c-ccg.github.io/did-method-key/
+[principal]:https://github.com/ucan-wg/spec/#321-principals
+[non-extractable keys]:https://crypto.stackexchange.com/questions/85587/what-do-people-use-non-extractable-webcrypto-keys-for/102695#102695
+[agent]:#agent
+[account]:#account
+[UCAN-IPLD Schema]:https://github.com/ucan-wg/ucan-ipld/#2-ipld-schema
+[link]:https://ipld.io/docs/schemas/features/links/
+[authorization payload]:#authorization-payload
+[RFC6376]:https://www.rfc-editor.org/rfc/rfc6376#section-3.4
+[Nonstandard `VarSig` signature]:https://github.com/ucan-wg/ucan-ipld/#251-nonstandard-signatures
+[ABNF]:https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form
+[DAG-JSON]:https://ipld.io/specs/codecs/dag-json/spec/
+[authorization session]:./w3-session.md

--- a/w3-account.md
+++ b/w3-account.md
@@ -12,7 +12,7 @@
 
 # Abstract
 
-In w3 family of open protocols users interact with self-certified ([PKI] baked) namespaces. Access to such namespaces is managed through delegated [UCAN] capabilities that need to be synced across multiple user agents on multiple devices. Doing this in an open and decentralized system introduces unique UX challenges that we attempt to address through a concept of an **account** as described by this specification.
+The w3 family of open protocols defines user interactions with self-certified [PKI] based namespaces. These namespaces can be accessed through delegated [UCAN] capabilities that must be synchronized across multiple user agents on multiple devices. Since this is an open and decentralized system, there are unique challenges in providing a user-friendly experience, which is addressed through the concept of an **account** as described in this specification.
 
 ## Language
 
@@ -20,16 +20,16 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # Introduction
 
-In web3 namespace is simply [`did:key`] identifier. As a result, [principal] identified by the [`did:key`] is an owner of that namespace with a absolute authority over it. It can delegate some or all of the capabilities for the resources under that namespace to any other [principal]. However managing delegations across various user agents has several UX challenges:
+In w3 family of protocols, a namespace is identified by a [`did:key`] identifier, which means that the owner of that namespace _(private key holder)_ has absolute authority over it. They can delegate some or all of the capabilities for the resources under that namespace to any other [principal]. However, managing these delegations across multiple user agents on multiple devices presents several user experience challenges:
 
-1. Syncing delegations to namespace(s) across multiple user agents on multiple devices introduces discovery problem, challenged by use of not memorable [`did:key`] identifiers.
-2. Recovering access in case where user loses access to all of the devices.
+1. Synchronizing delegations to namespaces across multiple user agents on multiple devices is difficult because of the use of non-memorable [`did:key`] identifiers.
+2. Recovering access if the user loses access to all devices is also a challenge.
 
-We propose concept of an account as convenience for aggregating and managing capabilities under human-meaningful identifier like an email address. More specifically we propose deriving account [`did:mailto`] identifier from user controlled email address, so it can act as [principal] in [UCAN] delegation chains.
+To address these issues, we propose the concept of an account as a way to aggregate and manage capabilities under a human-meaningful identifier such as an email address. Specifically, we propose deriving an account identifier from a user-controlled email address in the form of a [`did:mailto`] identifier, which can act as the [principal] in [UCAN] delegation chains.
 
-User can aggregate all delegations under such an account identifier and re-delegate desired capabilities to other agents. Use of memorable identifier addresses discovery problem. Furthermore email address as an account provides smooth web3 onboarding experience by hiding all of the [PKI] under familiar email based authorization flows.
+Using an account identifier based on a memorable email address solves the discovery problem, and email-based authorization flows provide a smoother onboarding experience by hiding the complexity of [PKI]. With this approach, users can aggregate all of their delegations under a single account identifier and re-delegate desired capabilities to other agents.
 
-> ℹ️ This specification is focuses on [`did:mailto`] identifiers, however approach can easily be extended to various other identifiers.
+> ℹ️ This specification mainly focuses on [`did:mailto`] identifiers, but it can be extended to various other types of identifiers.
 
 # High-Level Concepts
 
@@ -44,19 +44,13 @@ There are several distinct roles that [principals] may assume in described speci
 
 ### Account
 
-_Account_ is a [principal] identified by a memorable identifier like [`did:mailto`].
-
-Account MAY be used for convenience of aggregating and managing capabilities across various user [Agent]s.
-
-Account CAN be used to facilitate familiar user authorization and recovery flows.
+An _account_ is a principal that is identified by a memorable identifier such as [`did:mailto`]. It can be used for the convenience of aggregating and managing capabilities across various user [agent]s. Additionally, an account can facilitate familiar user authorization and recovery flows.
 
 ### Agent
 
-_Agent_ is a [principal] identified by a [`did:key`] identifier.
+An _agent_ is a [principal] that is identified by a [`did:key`] identifier. Users interact with a system through different _agents_ across multiple devices and applications. It is strongly RECOMMENDED that _agents_ use [non-extractable keys] when possible.
 
-Users interacts with a system through different _agents_ across multiple devices and applications. It is highly RECOMMENDED that _agents_ use [non-extractable keys] when possible.
-
-> ℹ️ _Agents_ are meant to be ephemeral that could be disposed or created on demand.
+> ℹ️ Note that _agents_ are meant to be ephemeral, which means that they could be disposed of or created on demand.
 
 # Protocol
 
@@ -64,27 +58,28 @@ Users interacts with a system through different _agents_ across multiple devices
 
 ### Aggregating capabilities
 
-Any [`did:key`] identified [agent] CAN (re)delegate capabilities to [`did:mailto`] identified [account] per [UCAN] specification. This MAY be used to delegate complete authority over created namespace on creation.
+Any [agent] identified by a [`did:key`] CAN delegate or re-delegate capabilities to an [account] identified by a [`did:mailto`] according to the [UCAN] specification. This CAN be used to delegate complete authority over a created namespace at the time of creation.
 
 ```mermaid
 sequenceDiagram
 actor Alice
-participant W3 as 💻<br/><br/>web3.storage #32;
+participant App as 💻<br/><br/>w3up #32;
 participant Space as 📦<br/><br/>did:key:z6Mkk…sxALi
 participant Email as 📫 alice@web.mail
 
 
-W3 -->> Alice: What is your email ?
-Alice -->> W3: alice@web.mail
-W3->>Space:🔑 Create namespace
+Note right of Alice: Authorization
+App -->> Alice: What is your email ?
+Alice -->> App: alice@web.mail
+App->>Space:🔑 Create namespace
 
 Space ->> Email: 🎫 Delegate capabilities
-note over Space,Email:can:*<br/>with: ucan:/*
+note over Space,Email:can:*<br/>with: ucan:*
 ```
 
-> On first run new namespace is generated and complete authority is delegated to the user account
+> During the first run, a new namespace is generated and complete authority is delegated to the user account. Illustration leaves out steps in which application attempts to claim capabilities before deciding to create a new space.
 
-Any user CAN (re)delegate capabilities to their peer by delegating to their [`did:mailto`] identified [account] _(which can be derived from the email address)_. Also note that no setup is required from delegate until they decide to invoke delegated capability.
+Any user CAN delegate or re-delegate capabilities to their peer by delegating to their [account] identified by a [`did:mailto`] _(which can be derived from their email address)_. It's worth noting that no setup is required from the delegate until they decide to invoke the delegated capability.
 
 ```mermaid
 sequenceDiagram
@@ -98,31 +93,31 @@ note over Alice,Bob:<br/>with: space://z6Mkr…jnz2z<br/>can:store/add
 Email ->> Bob: 🎫 Delegate capabilities
 ```
 
-> **Alice** delegates `store/add` capability to **Bob**, who later creates an agent and re-delegates capability to it.
+> **Alice** delegates the `store/add` capability to **Bob**, who later creates an agent and re-delegates the capability to it.
 
 ### Delegating capabilities
 
-Delegating capabilities from [`did:mailto`] identified [account] to an [agent] is less straightforward, because signing key is not self-evident from the delegation.
+Delegating capabilities from an [account] identified by a [`did:mailto`] to an [agent] is less straightforward because the signing key is not self-evident from the delegation.
 
-Here we propose extension to the [UCAN] specification to allow signing and verification of [`did:mailto`] issued delegations without requiring a [`did:mailto`] key resolution.
+To address this issue, we propose an extension to the [UCAN] specification that allows signing and verification of delegations issued by [`did:mailto`] without requiring a [`did:mailto`] key resolution.
 
-We define two alternative signature types with a different tradeoffs. Protocol implementer MAY support either or both signature types.
+We define two alternative signature types that have different trade-offs, and protocol implementers MAY choose to support either or both signature types.
 
-> ℹ️ Signatures for [account]s identified by other DID methods is left undefined.
+> ℹ️ The signatures for [account]s identified by other DID methods are not defined.
 
 #### DomainKeys Identified Mail (DKIM) Signature
 
-Delegation issued by an [account] identified with [`did:mailto`] identifier MAY be signed using DKIM-Signature DomainKeys Identified Mail ([DKIM]) Signature.
+An [account] identified with the [`did:mailto`] identifier MAY issue a delegation that is signed using a DomainKeys Identified Mail ([DKIM]) signature.
 
-Signature MUST be generated by sending a message from the email address of the [account] with a `Subject` header set to an [authorization payload].
+The signature MUST be generated by sending a message from the email address of the [account] with a `Subject` header set to an [authorization payload].
 
-Signer MUST derive "DKIM payload" from the received message per [RFC6376] specification and encode it in UTF-8 encoding. Resulting bytes MUST be encoded as a [Nonstandard `VarSig` signature] with `DKIM` string as an `alg` parameter.
+The signer MUST derive the "DKIM payload" from the received message according to the [RFC6376] specification and encode it in UTF-8 encoding. The resulting bytes MUST be encoded as a [Nonstandard `VarSig` signature] with the `alg` parameter set to `"DKIM"`.
 
 ##### Authorization Payload
 
-> ℹ️ Using UCAN standard signing payload would result in a large signatures, which is why we define an alternative payload format.
+> ℹ️ Note that the UCAN standard signing payload would results in large signatures. Therefore, we propose an alternative payload format.
 
-UCAN data model MUST be structured according to [UCAN-IPLD Schema] omitting `s` field. IPLD [link] of the data model must be derived and formatted according to following [ABNF] definition, where `cid` refers to derived link.
+The UCAN data model MUST follow the structure specified in the [UCAN-IPLD Schema], but the `s` field should be omitted. The IPLD [link] of the data model must be derived and formatted according to the [ABNF] definition below, where `cid` refers to the derived link:
 
 ```abnf
 auth := "I am signing ipfs://" cid "to grant access to this account"
@@ -131,12 +126,12 @@ cid  := z[a-km-zA-HJ-NP-Z1-9]+
 
 #### Authorization Session Signature
 
-Delegation issued by an [account] identified with [`did:mailto`] identifier MAY use _authorization session_ signature in conjunction with an [authorization session] (issued by trusted [authority]). If delegation has a proof with such signature, it MUST also have a qualified [authorization session]. If authorization session is not present in the proofs validator MUST carry out an out-of-bound authorization flow to obtain [authorization session] on demand. If validator is unable to carry out authorization flow, it MUST consider signature invalid.
+Delegation issued by [account] identified with the [`did:mailto`] identifier MAY be
+signed using _authorization session signature_. However, this signature alone does not verify that the [account] owner authorized the delegation. For this reason, the delegation MUST also have an accompanying [authorization session] issued by a trusted [authority] that confirms the authorization by the [account] owner. In situations where the [authorization session] is not present in the proof, the validator is required to obtain it through an out-of-band authorization flow upon request. Failure to carry out this authorization flow will result in the signature being considered invalid.
 
 ##### Authorization Session Signature Format
 
-The [Nonstandard `VarSig` signature] with `0` bytes MUST be used.
-This type of signature is encoded as a "NonStandard" [VarSig] with 0 bytes, which is shown in [DAG-JSON] format below
+The authorization session signature is denoted by a [Nonstandard `VarSig` signature] with zero (`0`) signature bytes.
 
 ##### Authorization Session Signature Example
 
@@ -144,33 +139,6 @@ This type of signature is encoded as a "NonStandard" [VarSig] with 0 bytes, whic
 
 ```jSON
 { "/": { "bytes": "gKADAA" } }
-```
-
-### Signup
-
-### Authorization
-
-> On first run **w3.app** request `store/*` capability from **alice@web.mail** through **web3.storage**, which performs out of bound email authorization and delegates granted capability.
-
-```mermaid
-sequenceDiagram
-actor Alice
-participant App as 💻 w3.app
-participant W3 as 🌐<br/><br/>did:web:web3.storage #32;
-participant Email as 📫 alice@web.mail
-
-
-App -->> Alice: What is your email ?
-Alice -->> App: alice@web.mail
-App ->> W3: Can I store/* ❓
-W3 -->> Email: Can w3.app store/* ❓
-note over W3,Email: space://z6Mkk…sxALi<br/>can: store/*<br/>#32;<br/>space://z6Mk…n9bob<br/>can: store/*
-
-
-Email -->> W3: ✉️ grant
-note over Email,W3:with: space://z6Mkk…sxALi<br/>can: store/*
-W3 ->> App: 🎫 delegate
-Note over W3,App:with: space://z6Mkk…sxALi<br/>can:store/*
 ```
 
 [Protocol Labs]:https://protocol.ai/

--- a/w3-session.md
+++ b/w3-session.md
@@ -32,9 +32,8 @@ To address this, we propose an alternative method for delegating capabilities fr
 
 There are several roles that agents in the authorization flow may assume:
 
-| Name        | Description                                                                                                                                    |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
----------------------------------------------------------------- |
+| Name        | Description |
+| ----------- | ----------- |
 | Account    | [Principal] identified by memorable identifier like [`did:mailto`]. |
 | Agent       | [Principal] identified by [`did:key`] identifier, representing a user in some application installation |
 | Oracle      | [Principal], entrusted by [Authority] to carry out out-of-bound authorization flow |

--- a/w3-session.md
+++ b/w3-session.md
@@ -22,9 +22,19 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Motivation
 
-In web3.storage users may create (name)space by generating an asymmetric keypair and deriving [`did:key`] identifier from it. (Name)space owner (private key owner) can delegate some or all capabilities to other identifiers without anyone's permission, however managing keypairs across multiple agents and devices can be complicated.
+In web3.storage users may create (name)space by generating an asymmetric keypair and deriving [`did:key`] identifier from it. (Name)space owner (private key holder) can delegate some or all the (name)space capabilities to other identifiers without anyone's permission, however there are several UX challenges in this setup:
 
-We propose [petname][] inspired approach that allows mapping cryptographic [`did:key`] identifiers to a memorable identity. This specification focuses on [`did:mailto`] identifiers, however approach is valid and can be extended to various other identifiers.
+1. Getting delegations synced across multiple user agents on multiple devices can prove challenging as agent would need discover each others DIDs without making user memorizing or typing them.
+2. Recovering account access when both (name)space key and all devices are lost.
+
+Here we propose use of user email address for deriving account [`did:mailto`] identifiers. User owned [`did:mailto`] UCAN principal can act as delegations hub:
+
+1. All participating user agents can delegate capabilities to such an identifier (natively with UCANs).
+2. New user agents can request delegation for required capabilities from user [`did:mailto`] principal.
+
+In this document we propose a protocol through which user [agent] (identified by [`did:key`] identifier) could request set of desired capabilities from memorable [`did:mailto`] identifier through an intermediary facilitating out-of-bound user authorization. We also specify how **special** `./update` capability may be utilized by supporting agents for establishing authorization sessions.
+
+> ℹ️ This specification focuses on [`did:mailto`] identifiers, however approach is valid and can be extended to various other identifiers.
 
 # Terminology
 
@@ -34,21 +44,49 @@ There are several roles that agents in the authorization flow may assume:
 
 | Name        | Description                                                                                                                                    |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Identity    | Principal identified by a memorable identifier like [`did:mailto`]. Authorized agents will act on behalf of some identity                      |
-| Notary      | Trusted principal, an oracle that performed out-of-bound authentication and issuer of the [authorization session]                              |
-| Authority   | An agent that interprets a UCAN and verifies that it is valid                                                                                  |
-| Session key | The [`did:key`] identifier of the key that is used to sign UCANs issued by Identity. Usually this is a DID of the Agent authorized as Identity |
+| Account    | UCAN Principal identified using memorable identifier like [`did:mailto`]. |
+| Agent       | UCAN Principal identified using [`did:key`] identifier, representing a user in some application installation |
+| Oracle      | UCAN principal, entrusted by [Authority] to carry out out-of-bound authorization flow |
+| Authority   | UCAN Principal that represents service provider that executes invoked capabilities |
+| Verifier   | Component of the [authority] that performs UCAN validation |
 
-## Premise
+### Account
 
-Mapping cryptographic [`did:key`] identifier to an identity with memorable identifier like [`did:mailto`] MUST be authorized by the identity owner. When identity is identified with a a non-cryptographic identifier authorization is not self-evident from the UCAN delegation and requires performing out-of-bound authentication like [DID resolution] or an email based confirmation flow.
+_Account_ is a [UCAN Principal] identified with a memorable identifier like [`did:mailto`].
 
-To keep UCANs verifiable in stateless settings we propose capturing stateful information (out-of-bound authorization) in a stateless [session], represented using a UCAN, so it can be included in verifiable proofs.
+It MAY be used as a convenience for aggregating and managing capabilities across various user [Agent]s, facilitating familiar flows for account recovery and authorization.
 
-## Authorization
+### Agent
 
-An agent MAY request an authorization [session] by invoking `access/authorize` capability that specifies desired identity (`nb.as`) and session key (`with`).
-Capability provider (notary) MUST carry out-of-bound authentication that allows identity owner to accept or deny authorization request.
+Agent is a [UCAN Principal] identified by a [`did:key`] identifier.
+
+User interacts with a system through different _agents_ across multiple devices and application installations. _Agent_ keys are RECOMMENDED to be non-extractable.
+
+_Agents_ are meant to be ephemeral that could be disposed or created on demand.
+
+### Oracle
+
+_Oracle_ is a [UCAN Principal], facilitating out-of-bound account authorization flow. _Oracle_ is explicitly or implicitly trusted by the [authority] to carry out authorization in good faith and record the outcome in an issued [permit].
+
+### Authority
+
+_Authority_ is a [UCAN Principal] that executes invoked capabilities.
+
+### Verifier
+
+Component of the [authority] that performs UCAN validation
+
+# Protocol
+
+## Overview
+
+Delegating capabilities from [`did:key`] identifiers to memorable [`did:mailto`] identifiers is straightforward with UCANs due to cryptographic signatures. However delegation in opposite direction (from [`did:mailto`] to [`did:key`] principal) is not self-evident from the UCAN delegation and requires out-of-bound interaction like an email based authorization flow.
+
+To keep such UCANs delegation chains verifiable in stateless settings we propose capturing stateful information (out-of-bound authorization) in a stateless [session], represented using a UCAN delegation, that [Agent] could include in delegation proofs and avoid repeated user authorizations.
+
+## Authorization Request
+
+User [agent] MAY request an authorization from the user [account] by invoking `access/authorize` capability through a trusted [oracle] facilitating out-of-bound authorization.
 
 ```mermaid
 sequenceDiagram
@@ -56,143 +94,472 @@ sequenceDiagram
   participant W3 as 🌐<br/><br/>did:web:web3.storage #32;
   participant Email as 📬<br/><br/>alice@web.mail
 
-  Agent ->> W3: access/authorize
-  Note right of Agent:🎟<br/>with: did:key:zAgent<br/>as: did:mailto:web.mail:alice
-  W3 ->> Email: ✉️ Verification email
-  Email ->> W3: 🔗 Approve
+  Agent ->> W3: access/claim
+  
+  W3 ->> Email: ✉️ Confirm Authorization 
+  Email ->> W3: 🔗 Grant Authorization
   W3 -->> Agent: ./update
-    Note right of Agent:🎫<br/>with: did:web:web3.storage<br/>key: did:key:zAgent
 ```
+
+### Authorization Request Schema
+
+```ipldsch
+# Authorization protocol consists of a single `Claim` capability.
+type Access union {
+  | Claim   "access/claim"
+} representation inline {
+  discriminantKey "can"
+}
+
+
+type Claim struct {
+  # DID of the agent requesting an authorization
+  with  Agent
+  # Authorization request describing set of desired capabilities
+  nb    AuthorizationRequest
+}
+
+type AuthorizationRequest {
+  # DID of the Account authorization is requested from.
+  iss optional Account
+  # Capabilities requesting agent wishes to be granted.
+  att [CapabilityRequest]
+}
+
+type CapabilityRequest struct {
+  # Describes the request capability. If set to `*` implies desire to have
+  # complete authority over the account and is equivalent to "sudo" access.
+  can    string
+}
+
+type Agent DIDKey
+type Account DIDMailto
+```
+
+#### Agent Requesting Authorization
+
+Resource (`with` field) MUST be set to [`did:key`] agent identifier requesting an authorization.
+
+> ℹ️ Note that it MAY be different from the issuer of the authorization request. The issuer is irrelevant, as long as it has been delegated `access/claim` capability from  the [agent].
+
+#### Account Granting Authorization
+
+The OPTIONAL `nb.iss` field, if specified MUST be set to the [account] DID from which desired capabilities (`nb.att`) are requested.
+
+If `nb.iss` field is omitted, request MUST be interpreted as desire to fetch UCAN delegations to the [agent] that match requested capabilities (described by `nb.iss` field).
+
+#### Requested Capabilities
+
+The `nb.att` field MUST conform to the `CapabilityRequest` [IPLD schema]. It MUST
+specify set of capabilities [agent] is requesting.
+
+The `{ "can": "*" }` is equivalent to [sudo] access and represents request for for [superuser] permissions and SHOULD be reserved for special cases.
+
+It is generally RECOMMENDED that [agent]s request only a set of capabilities needed to complete a user initiated action and when user initiates such action.
 
 ### Authorization Example
 
-> Request authorization from `alice@web.mail` with `did:key:zAgent`.
+> Agent `did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi` requests a `store/*` capability from `alice@web.mail` account
 
 ```json
 {
-  "iss": "did:key:zAgent", // agent
-  "aud": "did:web:web3.storage", // notary
+  "v": "0.9.1",
+  "iss": "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi",
+  "aud": "did:web:web3.storage",
   "att": [
     {
-      "with": "did:key:zAgent", // session key
+      "with": "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi",
       "can": "access/authorize",
-      "nb": { "as": "did:mailto:web.mail:alice" } // identity
+      "nb": {
+        "iss": "did:mailto:web.mail:alice",
+        "att": [{"can":"store/*"}]
+       }
     }
-  ]
+  ],
+  "prf": [],
+  "exp": 1685602800,
+  "s": {
+    "/": {
+      "bytes": "7aEDQJbJqmyMxTxcK05XQKWfvxG+Tv+LWCJeE18RSMnciCZ/RQ21U75LA0uFSvIjdqnF5RaauZTE8mh2ZYMBBejdJQ4"
+    }
+  }
 }
 ```
 
-### Authorization Principal
+## Authorization Permit
 
-The `nb.as` field MUST specify a principal that requesting agent wishes to represent in authorized session. It MUST be valid [UCAN principal] so that it can be used as issuer (`iss`) in UCANs covered by authorized session.
+An [oracle] MUST provide `access/claim` capability. When `access/claim` capability is invoked [oracle] MUST carry out an out-of-bound authorization flow allowing [account] holder to select capabilities they wish to grant. It is RECOMMENDED that [oracle] by default limit set of presented capability choices to a subset matching request criteria.
 
-### Authorization Key
+If user denied authorization request, [oracle] MUST fail corresponding `access/claim` invocation. Otherwise [oracle] MUST record authorization result as an IPLD node conforming to `Permit` [IPLD Schema].
 
-Resource (`with`) MUST be a [`did:key`][] identifier for the desired session key. It represents a key that agent wishes to use for signing [UCAN][]s that it will issue using authorization principal.
+### Authorization Permit Schema
 
-> Please note that session key `with`, MAY be different or same as the issuing agent DID (`iss`).
+The `Permit` is the same as [UCAN-IPLD] schema except for omitted proofs (`prf`) and and a signature (`s`).
 
-### Authentication
+```ipldsch
+type Permit struct {
+  v                 SemVer
+  iss               Account
+  aud               Agent
+  att               [Capability]
+  exp               Int
 
-Agent providing `access/authorize` capability (notary) MUST carry out-of-bound process in which authorizing principal may confirm or deny authorization. Process MAY vary based on type of identity.
+  fct               [Fact]
+  nnc   optional    String
+  nbf   optional    Int
+}
 
-#### Example [`did:mailto`] authorization
+type SemVer string
+```
 
-Notary MAY issue authorization [session] after verifying that specified [`did:key`] is authorized by either:
+#### Permit Version
 
-- Performing [`did:mailto` resolution] and ensuring it is listed under [capability invocations] when [DKIM-Signature] is provided.
+The `v` field MUST contain the SemVer-formatted version of the [UCAN-IPLD] schema.
 
-- Perform out-of-bound verification by sending an email to the corresponding address with a callback link that can authorize requested [`did:key`].
+#### Account Granting Authorization
 
-#### Example [`did:web`]
+The `iss` field MUST be set to the [Account] DID encoded as a [UCAN Principal]. Issuer MUST be set to the [account granting authorization] (`nb.iss` in the [authorization request]).
 
-Notary MAY issue authorization [session] after performing [DID resolution] and either:
+#### Agent Granted Authorization
 
-- Ensuring that specified [`did:key`] is authorized to perform [capability invocations].
-- Carry [DID authentication] using challenge-response protocol.
+The `aud` field MUST be set to the [Agent] DID encoded as a [UCAN Principal]. [Agent] MUST be set to the [agent requesting authorization] (`nb.with` in the [authorization request]).
 
-### Authorization context
+#### Authorized Capabilities
 
-Notary MUST issue [session] for the [authorization] request that was approved. This enables authorized agents (ones with access to session private key) to use UCANs covered by this [session].
+The `att` field MUST contain set of capabilities conforming to [UCAN Capability] schema. It MUST contain capabilities that [account] holder authorized through out-of-bound authorization flow.
 
-Authorization context extends to the principals that trust that notary has carried out authorization process is good faith.
+#### Authorization Expiry
 
-> To make it more concrete consider following scenario: **Alice** shares **Bobs** contact info with **Mallory** from her address book.
->
-> **Mallory** assumes shared phone number belongs to **Bob** because she trusts **Alice** to act in good faith.
+The `exp` field MUST be set to the expiration in UTC Unix Timestamp format. If the authorization explicitly never expires, the `exp` field MUST be set to `null`. If the `exp` time is in the past at validation time, the authorization MUST be treated as expired and invalid.
 
-#### Delegated Trust
+#### Authorization Facts
 
-Trust in notary CAN explicitly be captured via [session] delegating, in which case notary SHOULD re-delegate it. This allows modeling complex trust relationships where trusted authority delegates trust to some intermediary principal which (re)delegates this trust to the notary that issued a [session].
+The `fct` fields MUST contain arbitrary facts and proofs of knowledge. The `fct` field MUST be a list of nodes conforming to [UCAN Facts] schema.
 
-## Session
+#### Authorization Nonce
 
-Session is UCAN issued by (trusted) notary (`iss`) and proof that notary has verified that authorizing principal (`aud`) has approved use of session key (`with`) in the context of this session.
+The OPTIONAL `nnc` field MAY be set to arbitrary string. The `nnc` field MUST corresponds to [UCAN nonce].
 
-In other words notary has ensured that principal in `aud` field has approved UCAN issued by it to be signed using (`with`) key.
+#### Authorization Time
+
+The `nbf` field is OPTIONAL. When omitted, authorization MUST be treated as valid beginning from the Unix epoch. If the `nbf` time is in the future at the validation time, the authorization MUST be treated as invalid.
+
+### Example Permit in [DAG-JSON]
+
+```json
+{
+  "v": "0.9.1",
+  "iss": "did:mailto:web.mail:alice",
+  "aud": "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi",
+  "att": [
+    {
+      "can": "store/*",
+      "with": "space://did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL"
+    },
+    {
+      "can": "store/list",
+      "with": "space://did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob"
+    }
+  ],
+  "exp": 1685602800,
+  "fct": []
+}
+```
+
+## Authorization
+
+Authorization is a [UCAN] Delegation from [account] to an [agent], that conforms to the [Permit] schema. Because authorization is issued by the [account] principal signing key is not self-evident.
+
+Authorization signature depends on the DID method of the principal. This specification only defines signatures for the [`did:mailto`] principal. Signatures for other DID methods is left undefined.
+
+### DKIM Signed Authorization
+
+Authorization issued by [account] identified by [`did:mailto`] identifier MAY be signed using DKIM-Signature DomainKeys Identified Mail ([DKIM]) Signature header.
+
+Given `DKIM-Signature` format signing a whole UCAN payload would take up too much space. For this reason signer MUST encode it in a [permit] and sign it's IPLD [link].
+
+Signer MUST generate signature by sending an email from the [account] address and set `Subject` header to an [authorization message] derived from the [permit] [link]. `DKIM-Signature` from received email MUST be extracted and as UCAN signature.
+
+#### Authorization Message
+
+An authorization message MUST conform to the following [ABNF] definition, where `permit` is IPLD [link] to the derived [permit].
+
+```abnf
+auth := "Permit ipfs://" permit " granted after careful risk assessment"
+permit  := z[a-km-zA-HJ-NP-Z1-9]+
+```
+
+> ⚠️ As of this writing web3.storage does not yet support DKIM signed [UCAN]s.
+
+### Unsigned Authorization
+
+An unsigned authorization MAY be used to signal that [verifier] MUST confirm an authorization with an [account] holder using out-of-bound interaction, usually through an [oracle].
+
+This type of signature is encoded as a "NonStandard" [VarSig] with 0 bytes. In [DAG-JSON] format it corresponds to
+
+```jSON
+{ "/": { "bytes": "gKADAA" } }
+```
+
+This type of signature SHOULD be used in conjunction with [authorization session] that [oracle] CAN issue on behalf of the [authority].
+
+Authorization is an out-of-bound negotiation process between [agent] and an [account] carried out by the [oracle]. Details of the authorization process are left undefined to allow for wide range of domain specific applications.
+
+[UCAN]s issued by an [account] identified by [`did:mailto`] principal MAY be signed with [DKIM-Signature].
+
+#### Unsigned Authorization Example
+
+```json
+{
+  "bafyreif7xqul5yo4kk6ad32n37lzb74crjlrtfprfxydoq2cc3fyfrzru4": {
+    "v": "0.9.1",
+    "iss": "did:mailto:web.mail:alice",
+    "aud": "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi",
+    "att": [
+      {
+        "can": "store/*",
+        "with": "space://did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL"
+      },
+      {
+        "can": "store/list",
+        "with": "space://did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob"
+      }
+    ],
+    "prf": [
+      {
+        "/": "bafyreia5u55uto7pmucvd4hqzynmkddrxxj5wfxnc2owlxdju55yi77usq"
+      },
+      {
+        "/": "bafyreifqh3qvixqre7oa37lm5fi3xbwrhm7rsvhnclhvrp5fv76rz6thze"
+      }
+    ],
+    "exp": 1685602800,
+    "s": {
+      "/": {
+        "bytes": "gKADAA"
+      }
+    }
+  },
+  "bafyreia5u55uto7pmucvd4hqzynmkddrxxj5wfxnc2owlxdju55yi77usq": {
+    "v": "0.9.1",
+    "iss": "did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL",
+    "aud": "did:mailto:web.mail:alice",
+    "att": [
+      {
+        "can": "*",
+        "with": "space://did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL"
+      }
+    ],
+    "prf": [],
+    "exp": 1676618087,
+    "s": {
+      "/": {
+        "bytes": "7aEDQG+vMq7A2hnmKuj9s5yMEprtNVUVwfTgEri7/UCom8AK467pVnJyLk/3nwoT5901eBAAgyueOc5406rD9Ao1LgA"
+      }
+    }
+  },
+  "bafyreifqh3qvixqre7oa37lm5fi3xbwrhm7rsvhnclhvrp5fv76rz6thze": {
+    "v": "0.9.1",
+    "iss": "did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob",
+    "aud": "did:mailto:web.mail:alice",
+    "att": [
+      {
+        "can": "store/*",
+        "with": "space://did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob"
+      }
+    ],
+    "prf": [],
+    "exp": 1676618240,
+    "s": {
+      "/": {
+        "bytes": "7aEDQB6TdVUKh+TtggnvB7tcJbwLvFvT/RUQRkj7+YO6qUtT7FeD7cTq8DfSqPIrzSa/jtLAz0kAcQyAadrhSfpLPgs"
+      }
+    }
+  }
+}
+```
+
+## Authorization Session
+
+An authorization session is UCAN delegation from an [authority] to the [account]. Similarity to [DKIM Signature], it also represents an attestation from a trusted third party _(like an [oracle])_ that [account] holder has authorized delegation described by enclosed [permit].
+
+Session CAN be used as proof in [unsigned authorization] allowing [verifier] to leverage result of already carried out authorization flow.
+
+Session CAN also be used with [DKIM Signed Authorization]s allowing [verifier] to leverage result of prior domain key resolution and signature verification.
+
+### Schema
+
+```ipldsch
+type Session union {
+  | Authorization    "./update"
+} representation inline {
+  discriminantKey "can"
+}
+
+type Authorization struct {
+  with          Authority
+  nb            GrantedPermit
+}
+
+type GrantedPermit struct {
+  permit        &Permit
+}
+```
+
+#### Session Issuer
+
+Session MUST be issued by the [authority] or a trusted [oracle]. Issuing [oracle] MAY be trusted directly in which case [authority] has delegated `./update` capability to it, or transitively in which case [authority] had delegated `./update` capability to a principal that re-delegated it to an [oracle].
+
+#### Session Audience
+
+Session MUST be delegated to the [account] principal. This ensures [principal alignment] when linking it from the [authorization] proofs.
+
+#### Session Permit
+
+The `nb.permit` MUST [link] to the node conforming to the [Permit] IPLD schema. Implementation MUST support `Permit` in [DAG-CBOR] encoding. Implementation MUST support links with SHA-256 multihash.
+
+Support for any other encoding and hashing algorithm is not REQUIRED and is left up to implementation to decide.
+
+#### Session Context
+
+The `with` field MUST be set to the DID of the [authority], implying that session MAY be issued only by [oracle] to whom [authority] delegated `./update` capability.
+
+[Verifier] that encounters an [authorization] with session issued on behalf of own [authority] COULD verify a session and skip signature verification. This allows [verifier] to avoid repeated checks of [unsigned authorization].
 
 ### Session Example
 
-> Proof that `did:mailto:web.mail:alice` can issue UCANs signed with `did:key:zAgent` session key.
+> Proof that `did:mailto:web.mail:alice` has authorized `did:key:zAgent` to excercise `store/*` capabilities with `did:key:zAlice`.
 
 ```json
 {
-  "iss": "did:web:web3.storage",
-  "aud": "did:mailto:web.mail:alice",
-  "att": [
-    {
-      "with": "did:web:web3.storage",
-      "can": "./update",
-      "nb": { "key": "did:key:zAgent" }
+  "bafyreiat7z45tiyt52ju4h576xrmcmovkjl7ax22m5ndjij56ht4hqabba": {
+    "v": "0.9.1",
+    "iss": "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z",
+    "aud": "did:mailto:web.mail:alice",
+    "att": [
+      {
+        "can": "./update",
+        "nb": {
+          "permit": {
+            "/": "bafyreifer23oxeyamllbmrfkkyvcqpujevuediffrpvrxmgn736f4fffui"
+          }
+        },
+        "with": "did:web:web3.storage"
+      }
+    ],
+    "prf": [
+      {
+        "/": "bafyreibsisg5agttkynykz4jqjhq6xfeipsrevlfxzepcmafe6ucfraxly"
+      }
+    ],
+    "exp": null,
+    "s": {
+      "/": {
+        "bytes": "7aEDQBj34uAed7Mup+aVCTKuUtcKWwJtzMZ5yPA6tptMrcRrbE3o7uHKG/wBqF+OKJYGY7epQOV+OUuzseZvXuJN2QI"
+      }
     }
-  ],
-  "sig": "..."
+  },
+  "bafyreibsisg5agttkynykz4jqjhq6xfeipsrevlfxzepcmafe6ucfraxly": {
+    "v": "0.9.1",
+    "iss": "did:web:web3.storage",
+    "aud": "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z",
+    "att": [
+      {
+        "can": "./update",
+        "with": "did:web:web3.storage"
+      }
+    ],
+    "prf": [],
+    "exp": null,
+    "s": {
+      "/": {
+        "bytes": "7aEDQPhRaOAFHq+R2px8hOnaFenFmTvQn9gfGaGTZcaQ0mAaVpw4G/14+h3ApFo264BkLw62ACqQv5OF8eq5667NvQU"
+      }
+    }
+  },
+  "bafyreifer23oxeyamllbmrfkkyvcqpujevuediffrpvrxmgn736f4fffui": {
+    "v": "0.9.1",
+    "iss": "did:mailto:web.mail:alice",
+    "aud": "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi",
+    "att": [
+      {
+        "can": "store/*",
+        "with": "space://did:key:z6MktafZTREjJkvV5mfJxcLpNBoVPwDLhTuMg9ng7dY4zMAL"
+      },
+      {
+        "can": "store/list",
+        "with": "space://did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob"
+      }
+    ],
+    "exp": 1685602800,
+    "fct": []
+  }
 }
 ```
 
-### Session Context
+### Session Scope
 
-Resource MUST be set to the trusted principal corresponding to the [authorization context](#authorization-context). It SHOULD match `aud` of the UCAN that uses [session](#session) in [proofs].
+Authorization session apply only to the UCANs that link to it in their [proofs]s. Sessions are subject to UCAN [time bounds] and [revocations][ucan revocation]. Only UCANs meeting standard [principal alignment] requirement are covered the session.
 
-Authority MAY choose to trust principal other than itself and therefor extend authorization context to those principals.
+### Session Extensions
 
-### Session Principal
+The `./update` capability provides functionality roughly equivalent of [`Set-Cookie`] HTTP header. It allows capturing stateful information in the stateless UCAN delegations.
 
-Audience of the [UCAN][] MUST be a non-cryptographic identifier of the authorizing principal. It MUST match [authorize `nb.as`] of the corresponding authorization request.
+Capability MAY include arbitrary session information in the `nb` along with `permit`.
+[Verifier] MUST ignored all other fields in the context of this specification, or put it differently MUST NOT impact authorization session handling.
 
-> This ensures [principal alignment] when [session] is used as a proof in [UCAN][] issued by the authorizing principal.
+### Session Verification
 
-### Session Key
+[Verifier] MUST consider [authorization] valid when all of the following are true:
 
-The `nb.key` field MUST be set to [`did:key`] identifier of the session key. It MUST be the same DID as [authorize `with`] of the authorization request.
+1. Authorization is issued by an [account].
+2. Authorization links to the valid session permitting it.
 
-## Session Scope
+[Verifier] MUST consider [session] valid when all of the following are true:
 
-Authorization [session] covers UCANs that include it in their [proofs] and are subject to UCAN [time bounds] and [revocations][ucan revocation]. Only UCANs meeting standard [principal alignment] requirement are covered by the [session], meaning UCAN MUST be issued by the `aud` of the included [session].
+1. Session is issued (`iss`) by an [oracle] authorized by [authority].
+1. Session is delegated to (`aud`) an [account] that issues [authorization].
+1. Session permits (`nb.permit`) an [authorization] it is linked from.
+1. Session context (`with`) is set to the [authority] DID.
+1. Session links to a valid `./update` capability delegation chain from [authority] to the [oracle].
+1. Current time is within session [time bounds].
+1. Session has not been revoked.
 
-## Session Extensions
-
-The `./update` capability provides functionality roughly equivalent of [`Set-Cookie`][] HTTP header. It allows capturing stateful information in the stateless UCAN delegations.
-
-Capability MAY include arbitrary session information besides `key` which MUST be ignored in the context of this specification, or put it differently MUST NOT impact authorization [session] handling.
-
-[session]: #session
-[petname]: https://en.wikipedia.org/wiki/Petname
+[session]: #authorization-session
 [`did:mailto`]: https://github.com/ucan-wg/did-mailto/
 [`did:key`]: https://w3c-ccg.github.io/did-method-key/
-[authorize `nb.as`]: #authorization-principal
-[authorize `with`]: #authorization-key
 [ucan]: https://github.com/ucan-wg/spec/
 [principal alignment]: https://github.com/ucan-wg/spec/blob/main/README.md#62-principal-alignment
-[authorization]: #authorization
 [`set-cookie`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
 [ucan revocation]: https://github.com/ucan-wg/spec/#28-revocation
-[`did:web`]: https://w3c-ccg.github.io/did-method-web/
-[did resolution]: https://www.w3.org/TR/did-core/#resolution
-[capability invocations]: https://www.w3.org/TR/did-core/#capability-invocation
-[did authentication]: https://www.w3.org/TR/did-core/#authentication
-[`did:mailto` resolution]: https://github.com/ucan-wg/did-mailto/blob/draft/README.md#read-resolve
 [dkim-signature]: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
 [time bounds]: https://github.com/ucan-wg/spec/#322-time-bounds
 [proofs]: https://github.com/ucan-wg/spec/#327-proof-of-delegation
 [ucan principal]: https://github.com/ucan-wg/spec/#321-principals
+[agent]:#agent
+[account]:#account
+[oracle]:#oracle
+[authority]:#authority
+[verifier]:#verifier
+[sudo]:https://en.wikipedia.org/wiki/Sudo
+[link]:https://ipld.io/docs/schemas/features/links/
+[DAG-CBOR]:https://ipld.io/specs/codecs/dag-cbor/
+[IPLD schema]:https://ipld.io/docs/schemas/
+[UCAN-IPLD]:https://github.com/ucan-wg/ucan-ipld/
+[account granting authorization]:#account-granting-authorization
+[authorization request]:#authorization-request
+[agent requesting authorization]:#agent-requesting-authorization
+[UCAN Capability]:https://github.com/ucan-wg/ucan-ipld/#22-capability
+[UCAN Facts]:https://github.com/ucan-wg/ucan-ipld/#23-fact
+[UCAN Nonce]:https://github.com/ucan-wg/spec/#323-nonce
+[superuser]:https://en.wikipedia.org/wiki/Superuser
+[permit]:#authorization-permit
+[authorization]: #authorization
+[DKIM]:https://www.rfc-editor.org/rfc/rfc6376.html
+[authorization message]:#authorization-message
+[ABNF]:https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form
+[VarSig]:https://github.com/ucan-wg/ucan-ipld/#25-signature
+[DAG-JSON]:https://ipld.io/specs/codecs/dag-json/spec/
+[DKIM Signature]:#dkim-signed-authorization
+[unsigned authorization]:#unsigned-authorization
+[DKIM Signed Authorization]:#dkim-signed-authorization


### PR DESCRIPTION
[🫣 preview](https://github.com/web3-storage/specs/blob/feat/auth+account/w3-session.md)

Updates session and account specs to de-tangle them from each other. Most importantly it updates `access/authorize` protocol so that apps can request needed capabilities as opposed to always gaining sudo capabilities.