### PR TITLE
update README with w3up name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
-# storage.service Specifications
+# w3up Specifications
 
-> This repository contains the specs for the .storage Protocol and associated subsystems.
+> This repository contains the specs for the w3up Protocol and associated subsystems.
 
 ## Understanding the meaning of the spec badges and their life cycle
 


### PR DESCRIPTION
I don't think we call this the .storage protocol anywhere, and it seems like it's idiomatic to call it the w3up protocol, so let's make it official?