### PR TITLE
feat: add merkle clock spec

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -94,3 +94,4 @@ flowAuthorityPrincipal
 capabilitiesVerifierComponent
 Verifier
 sudo
+merkle

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
-# storage.service Specifications
+# w3up Specifications
 
-> This repository contains the specs for the .storage Protocol and associated subsystems.
+> This repository contains the specs for the w3up Protocol and associated subsystems.
 
 ## Understanding the meaning of the spec badges and their life cycle
 

--- a/w3-clock.md
+++ b/w3-clock.md
@@ -1,0 +1,82 @@
+# Merkle Clock
+
+![wip](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square)
+
+## Editors
+
+* [Alan Shaw](https://github.com/alanshaw), [DAG House](https://dag.house/)
+
+## Authors
+
+* [Alan Shaw](https://github.com/alanshaw), [DAG House](https://dag.house/)
+
+## Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+## Abstract
+
+This specification describes a method of managing a [Merkle Clock](https://arxiv.org/pdf/2004.00107.pdf) via UCAN invocations. Specifically, we cover two capabilities: 
+
+1. Advancing a clock by adding a new event.
+2. Fetching the current head of the clock (the most recent event(s) as known to the clock).
+
+## Data Format
+
+The data format of a Merkle Clock event:
+
+IPLD Schema
+
+```ipldsch
+type Event struct {
+  parents [&Event]
+  data &Data
+}
+
+type Data = Any
+```
+
+## Advancing a clock
+
+An agent may invoke a `clock/advance` capability to advance the head of a merkle clock.
+
+### Example
+
+```js
+{
+  "iss": "did:key:zAlice",
+  "aud": "did:web:clock.web3.storage",
+  "att": [
+    {
+      "with": "did:key:zClock",
+      "can": "clock/advance",
+      "nb": {
+        "event": { "/": "bafkrei..." } // CID to a clock event
+      }
+    }
+  ],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+## Fetching the clock head
+
+An agent may invoke a `clock/head` capability to fetch the current head of the clock (the most recent event(s) as known to the clock).
+
+```js
+{
+  "iss": "did:key:zAlice",
+  "aud": "did:web:clock.web3.storage",
+  "att": [
+    {
+      "with": "did:key:zClock",
+      "can": "clock/head"
+    }
+  ],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+The invocation returns an array of CIDs to clock events.

--- a/w3-clock.md
+++ b/w3-clock.md
@@ -16,7 +16,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Abstract
 
-This specification describes a method of managing a [Merkle Clock](https://arxiv.org/pdf/2004.00107.pdf) via UCAN invocations. Specifically, we cover two capabilities:
+This specification describes a method of managing a [Merkle Clock](https://arxiv.org/pdf/2004.00107.pdf) of partially ordered events via UCAN invocations. Specifically, we define two capabilities:
 
 1. Advancing a clock by adding a new event.
 2. Fetching the current head of the clock (the most recent event(s) as known to the clock).
@@ -36,9 +36,19 @@ type Event struct {
 type Data = Any
 ```
 
+### `parents`
+
+The `parents` property of an event is an array of zero or more links to events that preceed it. The parent events SHOULD be the current _head_ of the clock the event is being added to.
+
+### `data`
+
+The `data` property of an event is application specific data that SHOULD describe the operation that occurred, such that a total order can always be derived independently from the partial order presented by the clock DAG.
+
 ## Advancing a clock
 
-An agent may invoke a `clock/advance` capability to advance the head of a merkle clock.
+An agent MAY invoke a `clock/advance` capability to advance the head of a merkle clock. The event block and other ancestor events MAY be sent with the invocation, to allow the receipient to advance their local clock without calling out to the IPFS network. Event blocks MUST be made available to the IPFS network to allow other participants to read and advance their clocks without receiving an explicit invocation.
+
+A successful invocation MUST return the new head of the receipients clock. The receipient may be the target of invocations from _other_ participants so the resultant head is not necessarily the single event sent in the invocation.
 
 ### Example
 
@@ -62,7 +72,9 @@ An agent may invoke a `clock/advance` capability to advance the head of a merkle
 
 ## Fetching the clock head
 
-An agent may invoke a `clock/head` capability to fetch the current head of the clock (the most recent event(s) as known to the clock).
+An agent MAY invoke a `clock/head` capability to fetch the current head of the clock (the most recent event(s) as known to the clock). The invocation returns an array of CIDs to clock events.
+
+### Example
 
 ```js
 {
@@ -78,5 +90,3 @@ An agent may invoke a `clock/head` capability to fetch the current head of the c
   "sig": "..."
 }
 ```
-
-The invocation returns an array of CIDs to clock events.

--- a/w3-clock.md
+++ b/w3-clock.md
@@ -16,7 +16,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Abstract
 
-This specification describes a method of managing a [Merkle Clock](https://arxiv.org/pdf/2004.00107.pdf) via UCAN invocations. Specifically, we cover two capabilities: 
+This specification describes a method of managing a [Merkle Clock](https://arxiv.org/pdf/2004.00107.pdf) via UCAN invocations. Specifically, we cover two capabilities:
 
 1. Advancing a clock by adding a new event.
 2. Fetching the current head of the clock (the most recent event(s) as known to the clock).

--- a/w3-clock.md
+++ b/w3-clock.md
@@ -38,7 +38,7 @@ type Data = Any
 
 ### `parents`
 
-The `parents` property of an event is an array of zero or more links to events that preceed it. The parent events SHOULD be the current _head_ of the clock the event is being added to.
+The `parents` property of an event is an array of zero or more links to events that precede it. The parent events SHOULD be the current _head_ of the clock the event is being added to.
 
 ### `data`
 
@@ -46,9 +46,9 @@ The `data` property of an event is application specific data that SHOULD describ
 
 ## Advancing a clock
 
-An agent MAY invoke a `clock/advance` capability to advance the head of a merkle clock. The event block and other ancestor events MAY be sent with the invocation, to allow the receipient to advance their local clock without calling out to the IPFS network. Event blocks MUST be made available to the IPFS network to allow other participants to read and advance their clocks without receiving an explicit invocation.
+An agent MAY invoke a `clock/advance` capability to advance the head of a merkle clock. The event block and other ancestor events MAY be sent with the invocation, to allow the recipient to advance their local clock without calling out to the IPFS network. Event blocks MUST be made available to the IPFS network to allow other participants to read and advance their clocks without receiving an explicit invocation.
 
-A successful invocation MUST return the new head of the receipients clock. The receipient may be the target of invocations from _other_ participants so the resultant head is not necessarily the single event sent in the invocation.
+A successful invocation MUST return the new head of the recipients clock. The recipient may be the target of invocations from _other_ participants so the resultant head is not necessarily the single event sent in the invocation.
 
 ### Example
 


### PR DESCRIPTION
This specification describes a method of managing a [Merkle Clock](https://arxiv.org/pdf/2004.00107.pdf) of partially ordered events via UCAN invocations.