### PR TITLE
fix: aggregate offer with should be w3s

### DIFF
--- a/w3-aggregation.md
+++ b/w3-aggregation.md
@@ -150,7 +150,7 @@ type Offer [OfferDetails]
   "iss": "did:web:web3.storage",
   "aud": "did:web:spade.storage",
   "att": [{
-    "with": "did:web:spade.storage",
+    "with": "did:web:web3.storage",
     "can": "aggregate/offer",
     "nb": {
       "offer": { "/": "bafy...many-cars" }, /* dag-cbor CID */


### PR DESCRIPTION
Synced with @Gozala today and it makes sense that `aggregate/offer` resource would be `web3.storage`. We should at it like we use spaces within web3.storage system. Spade have multiple customers, each one with its own (out of band negotiated terms)  resource within Spade.

Note: Actually `aggregate/get` was already in this format.