### PR TITLE
feat: w3filecoin spec with storefront aggregator broker and chain roles

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -111,6 +111,10 @@ Ucanto
 ucanto
 natively
 storageAggregatorPrincipal
-w3filecoinBrokerPrincipal
+w3filecoinDealerPrincipal
+SpadeChain
 SpadeChainPrincipal
+TrackerPrincipal
+16GiB
 NOP
+deduplicated

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -112,3 +112,4 @@ ucanto
 natively
 storageAggregatorPrincipal
 w3filecoinBrokerPrincipal
+spadeChainPrincipal

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -110,3 +110,5 @@ Fil
 Ucanto
 ucanto
 natively
+storageAggregatorPrincipal
+w3filecoinBrokerPrincipal

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -112,4 +112,5 @@ ucanto
 natively
 storageAggregatorPrincipal
 w3filecoinBrokerPrincipal
-spadeChainPrincipal
+SpadeChainPrincipal
+NOP

--- a/w3-aggregation.md
+++ b/w3-aggregation.md
@@ -28,9 +28,10 @@ There are several roles in the authorization flow:
 
 | Name        | Description |
 | ----------- | ----------- |
-| Storefront | [Principal] identified by [`did:web`] identifier, representing a storage API like web3.storage |
-| Aggregator | [Principal] identified by [`did:web`] identifier, representing a storage aggregator like w3filecoin |
-| Broker     | [Principal] that arranges filecoin deals with storage providers like spade |
+| Storefront  | [Principal] identified by [`did:web`] identifier, representing a storage API like web3.storage |
+| Aggregator  | [Principal] identified by `did:key` identifier, representing a storage aggregator like w3filecoin |
+| Broker      | [Principal] identified by `did:key` identifier that arranges filecoin deals with storage providers like spade |
+| Chain       | [Principal] identified by `did:key` identifier that tracks the filecoin chain |
 
 ### Storefront
 
@@ -40,13 +41,17 @@ A Storefront facilitates data storage services to applications and users, gettin
 
 ### Aggregator
 
-An _Aggregator_ is a type of [principal] identified by a [`did:web`] identifier.
+An _Aggregator_ is a type of [principal] identified by a `did:key` identifier.
 
 An Aggregator facilitates data storage into Filecoin deals by aggregating smaller data (Filecoin Pieces) into a larger piece that can effectively be stored with a Filecoin Storage Provider.
 
 ### Broker
 
-A _Broker_ is a type of [principal] that arranges deals for the aggregates submitted by _Storefront_.
+A _Broker_ is a type of [principal] identified by a `did:key` identifier that arranges deals for the aggregates submitted by _Storefront_.
+
+### Chain
+
+A _Chain_ is a type of [principal] identified by a `did:key` that tracks the filecoin chain to keep a view of successful deals.
 
 # Protocol
 
@@ -58,74 +63,81 @@ A Storefront is the entry point for user/application data into web3. It will act
 
 Broker MUST have an authorization mechanism for allowed Storefront principals (e.g. web3.storage). Either by out of band exchange of information or through a well defined API. For example, a broker can authorize invocations from `did:web:filecoin.web3.storage` by validating the signature is from the DID. This way, it allows web3.storage to rotate keys and/or re-delegate access without having to coordinate with the broker.
 
-### Storefront receives and verifies a piece
+### Storefront receives a Filecoin piece
 
-When a Storefront's user (agent) intends to store a given content into a Filecoin Storage Provider, its proof SHOULD be computed (commonly known as Filecoin Piece) by the client and added to the Storefront. The aggregator MAY decide to verify the piece before submitting it to be aggregated, depending on a out of band trust model.
+When a Storefront's user (agent) intends to store a given content into a Filecoin Storage Provider, its proof SHOULD be computed (commonly known as Filecoin Piece) by the client and added to the Storefront. Note that Storefront MAY decide to compute the piece without waiting for an Agent to store received content into a Filecoin deal, or verify the agent claimed one. Storefront MUST acknowledge a request by issuing a signed receipt.
+
+Once a Storefront receives the offer of a piece by an agent, the piece gets queued for verification. A receipt is created to proof the transition of the added piece state from `null` into `queued` for verification. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it has no effect.
+
+This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the piece was accepted) or fails, so that its receipt COULD be looked up using it.
+
+After a storefront dequeues the piece and verifies it, a receipt is created to proof the transition of the aggregate state from `queued` into `accepted` or `rejected`. This receipt MUST have link to a followup task (using `.fx.join` field) with `piece/add`.
 
 ```mermaid
 sequenceDiagram
-    participant Agent as 🌐<br/><br/>did:key:abc...
-    participant Storefront as 🌐<br/><br/>did:web:web3.storage
+    actor Agent as <br/><br/>did:key:a...
+    actor Storefront as <br/><br/>did:web:web3.storage
 
-    Agent->>Storefront: invoke `piece/add`
-    Note left of Storefront: Request piece to be added
-    Storefront-->>Agent: receipt issued
-    Note left of Storefront: `piece/verify` might be invoked
+    Agent->>Storefront: invoke `filecoin/add`<br>with:`did:key:aSpace`
+    Note left of Storefront: Request piece to be added to filecoin deal
+    Storefront->>Storefront: invoke `filecoin/add`<br>with:`did:key:filecoinQueue`
+    activate Storefront
+    Storefront-->>Agent: receipt issued as `queued`
+    Storefront->>Storefront: invoke `filecoin/add`<br>with:`did:web:web3.storage`
+    deactivate Storefront
+    Storefront-->>Agent: receipt issued<br>fx: `piece/add`
 ```
 
 ### Storefront offers a piece to aggregate
 
 Once a Storefront receives a valid piece, it MAY be offered for aggregation, so that it makes its way into a Storage Provider. Aggregation MAY be handled asynchronously, therefore the Aggregator MUST acknowledge a request by issuing a signed receipt.
 
-```mermaid
-sequenceDiagram
-    participant Storefront as 🌐<br/><br/>did:web:web3.storage
-    participant Aggregator as 🌐<br/><br/>did:web:filecoin.web3.storage
-
-    Storefront->>Aggregator: invoke `piece/offer`
-    Note left of Aggregator: Request piece to be aggregated
-    Aggregator-->>Storefront: receipt issued
-```
-
-### Aggregator queues the piece
-
-Once an Aggregator successfully receives a piece offer, the piece gets queued for aggregation. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for a piece that is already `queued` or `computed` it is ignored.
+Once an Aggregator successfully receives a piece offer, the piece gets queued for aggregation. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it has no effect.
 
 This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the piece was added into an aggregate) or fails, so that its receipt COULD be looked up using it.
 
-### Aggregator offers broker an aggregate
-
-When the Aggregator has enough content to fulfill an aggregate (each broker MAY have different requirements), a Filecoin deal for an aggregate MAY be requested by an `aggregate/offer` invocation. Deal negotiations with Filecoin Storage Providers MAY be handled out of band. A broker MUST acknowledge a request by issuing a signed receipt.
+After an aggregator dequeues the piece, it will be included into an aggregate to be offered for Storage Providers. A receipt is created to proof the transition of the aggregate state from `queued` into `accepted` or `rejected`. If successful, a inclusion proof should also be provided.
 
 ```mermaid
 sequenceDiagram
-    participant Aggregator as 🌐<br/><br/>did:web:filecoin.web3.storage
-    participant Broker as 🌐<br/><br/>did:web:spade.storage
+    actor Storefront as <br/><br/>did:web:web3.storage
+    actor Aggregator as <br/><br/>did:key:agg...
 
-    Aggregator->>Broker: invoke `aggregate/offer`
-    Note left of Broker: Request offer to be queued
-    Broker-->>Aggregator: receipt issued
+    Storefront->>Aggregator: invoke `piece/add`<br>with:`did:web:web3.storage`
+    Note left of Aggregator: Request piece to be included in aggregate
+    Aggregator->>Aggregator: invoke `piece/add`<br>with:`did:key:pieceQueue`
+    activate Aggregator
+    Aggregator-->>Storefront: receipt issued as `queued`
+    Aggregator->>Aggregator: invoke `piece/add`<br>with:`did:key:agg...`
+    deactivate Aggregator
+    Aggregator-->>Storefront: receipt issued <br>with inclusion proof
 ```
 
-### Broker queues the aggregate
+### Aggregator offers broker an aggregate
 
-Once a Broker successfully receives the offer of an aggregate, the aggregate gets queued for review. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for an aggregate that is already `queued` or `complete` it is ignored.
+When the Aggregator has enough content to fulfill an aggregate (each broker MAY have different requirements), a Filecoin deal for an aggregate MAY be requested by an `aggregate/offer` invocation. Deal negotiations with Filecoin Storage Providers MAY be handled out of band. Broker MUST acknowledge a request by issuing a signed receipt.
+
+Once a Broker successfully receives the offer of an aggregate, the aggregate gets queued for deals with Storage Providers. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for an aggregate that is already `queued` or `accepted`, it has no effect.
 
 This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the aggregate was added into a deal) or fails (if the aggregate was determined to be invalid) so that its receipt COULD be looked up using it.
 
-> Note: Aggregator MAY have several intermediate steps and states it transitions through, however those intentionally are not captured by this protocol, because storefront will take no action until success / failure condition is met.
-
-### Broker reviews and handles the aggregate
-
 After a broker dequeues the aggregate, it will interact with available Filecoin Storage Providers, in order to establish a previously determined (out of band) number of deals. Depending on storage providers availability, as well as the content present in the offer, the aggregate MAY be handled or not. A receipt is created to proof the transition of the aggregate state from `queued` into `accepted` or `rejected`.
+
+> Note: Broker MAY have several intermediate steps and states it transitions through, however those intentionally are not captured by this protocol, because storefront will take no action until success / failure condition is met.
 
 ```mermaid
 sequenceDiagram
-    participant Aggregator as 🌐<br/><br/>did:web:filecoin.web3.storage
-    participant Broker as 🌐<br/><br/>did:web:spade.storage
+    actor Aggregator as <br/><br/>did:key:agg...
+    actor Broker as <br/><br/>did:key:brk...
 
-    Note right of Aggregator: Review and handle offer async
-    Broker-->>Aggregator: receipt issued
+    Aggregator->>Broker: invoke `aggregate/add`<br>with:`did:key:agg...`
+    Note left of Broker: Request aggregate to be queued for deal proposal
+    Broker->>Broker: invoke `aggregate/add`<br>with:`did:key:aggregateQueue`
+    activate Broker
+    Broker-->>Aggregator: receipt issued as `queued`
+    Broker->>Broker: invoke `aggregate/add`<br>with:`did:key:brk...`
+    deactivate Broker
+    Broker-->>Aggregator: receipt issued with `accepted` or `rejected`
 ```
 
 If the aggregate reaches the `accepted` state, the broker takes care of renewing deals.
@@ -134,14 +146,15 @@ The broker MAY request an out of bound signature from the Storefront to validate
 
 ### Storefront can query state of the aggregate deals
 
-Storefront users MAY want to check details about deals from the content they previously stored. These deals will change over time as they get renewed. Therefore, Storefront should invoke `aggregate/get` capability to gather information about given aggregate identifier.
+Storefront users MAY want to check details about deals from the content they previously stored. These deals will change over time as they get renewed. Therefore, Storefront should invoke `chain/info` capability to gather information about given aggregate identifier. Storefront should be able to look into previously received inclusion proofs to get the aggregate to look at based on the requested piece.
 
 ```mermaid
 sequenceDiagram
-participant Storefront as 🌐<br/><br/>did:web:filecoin.web3.storage
-    participant Broker as 🌐<br/><br/>did:web:spade.storage
+    actor Storefront as <br/><br/>did:web:web3.storage
+    actor Chain as <br/><br/>did:key:chain...
 
-    Storefront->>Broker: invoke `aggregate/get`
+    Storefront->>Chain: invoke `chain/info`
+    Note left of Chain: Request Chain for information from given piece
 ```
 
 ## Capabilities
@@ -150,9 +163,9 @@ This section describes the capabilities that form the w3 aggregation protocol, a
 
 In this document, we will be exposing capabilities implemented by Storefront `web3.storage`, Aggregator `filecoin.web3.storage` and Broker `spade-proxy.web3.storage`.
 
-### `piece/add`
+### `filecoin/add`
 
-An agent principal can invoke a capability to add a piece to upcoming Filecoin deal(s) with a Storage provider. See [schema](#pieceadd-schema).
+An agent principal can invoke a capability to add a piece to upcoming Filecoin deal(s) with a Storage provider. See [schema](#filecoinadd-schema).
 
 > `did:key:abc...` invokes capability from `did:web:web3.storage`
 
@@ -162,9 +175,9 @@ An agent principal can invoke a capability to add a piece to upcoming Filecoin d
   "aud": "did:web:web3.storage",
   "att": [{
     "with": "did:key:abc...",
-    "can": "piece/add",
+    "can": "filecoin/add",
     "nb": {
-      "link": { "/": "bag..." }, /* CID of CAR file previously added to resource space */
+      "content": { "/": "bag..." }, /* CID of file previously added to resource space */
       "piece": { "/": "commitment...car" } /* commitment proof for piece */
     }
   }],
@@ -180,11 +193,12 @@ Storefront MUST issue a signed receipt to acknowledge the received request. Issu
   "ran": "bafy...invocation",
   "out": {
     "ok": {
-      "status": "queued-for-verification"
+      "piece": { "/": "commitment...car" }, /* commitment proof for piece */
+      "status": "queued"
     }
   },
   "fx": {
-    "join": { "/": "bafy...dequeu-verification" }
+    "join": { "/": "bafy...dequeue" }
   },
   "meta": {},
   "iss": "did:web:web3.storage",
@@ -192,11 +206,9 @@ Storefront MUST issue a signed receipt to acknowledge the received request. Issu
 }
 ```
 
-See [`piece/verify`](#pieceverify) section to see the subsequent task.
+When piece request to be added is dequeued, storefront should invoke `filecoin/add` to store it.
 
-### `piece/verify`
-
-When a storefront principal receives a `piece/add` invocation from an agent, an [Effect](https://github.com/ucan-wg/invocation/#7-effect) for verifying the computed piece is created with join task to be performed asynchronously. See [schema](#pieceverify-schema).
+> `did:web:web3.storage` invokes capability from `did:web:web3.storage`
 
 ```json
 {
@@ -204,9 +216,9 @@ When a storefront principal receives a `piece/add` invocation from an agent, an 
   "aud": "did:web:web3.storage",
   "att": [{
     "with": "did:web:web3.storage",
-    "can": "piece/verify",
+    "can": "filecoin/add",
     "nb": {
-      "link": { "/": "bag..." }, /* CID of CAR file previously added to resource space */
+      "content": { "/": "bag..." }, /* CID of file previously added to resource space */
       "piece": { "/": "commitment...car" } /* commitment proof for piece */
     }
   }],
@@ -215,9 +227,7 @@ When a storefront principal receives a `piece/add` invocation from an agent, an 
 }
 ```
 
-Once this invocation is executed, a receipt MUST be generated with the result of the task. Issued receipt MUST contain an [effect](https://github.com/ucan-wg/invocation/#7-effect) with a subsequent task (`.fx.join` field) that is run when piece is queued for aggregation and either succeeds (implying that piece was queued for being offered) or fails (with `error` describing the problem).
-
-Accepted piece receipt looks like:
+Storefront MUST issue a signed receipt to communicate the response for the request. Issued receipt MUST contain an [effect](https://github.com/ucan-wg/invocation/#7-effect) with a subsequent task (`.fx.join` field) that is invoked to get a piece into an aggregate.
 
 ```json
 {
@@ -225,11 +235,11 @@ Accepted piece receipt looks like:
   "out": {
     "ok": {
       "piece": { "/": "commitment...car" }, /* commitment proof for piece */
-      "status": "queued-for-offer"
+      "status": "accepted"
     }
   },
   "fx": {
-    "join": { "/": "bafy...dequeue-piece" }
+    "join": { "/": "bafy...piece...add" }
   },
   "meta": {},
   "iss": "did:web:web3.storage",
@@ -237,8 +247,7 @@ Accepted piece receipt looks like:
 }
 ```
 
-See [`piece/offer`](#pieceoffer) section to see the subsequent task.
-
+See [`piece/add`](#pieceadd) section to see the subsequent task.
 If the added piece is invalid, details on failing reason is also reported:
 
 ```json
@@ -259,22 +268,22 @@ If the added piece is invalid, details on failing reason is also reported:
 }
 ```
 
-### `piece/offer`
+### `piece/add`
 
-A storefront principal can invoke a capability to offer a piece to be aggregated for upcoming Filecoin deal(s). See [schema](#pieceoffer-schema).
+A storefront principal can invoke a capability to offer a piece to be aggregated for upcoming Filecoin deal(s). See [schema](#pieceadd-schema).
 
-> `did:web:web3.storage` invokes capability from `did:web:filecoin.web3.storage`
+> `did:web:web3.storage` invokes capability from `did:key:agg...`
 
 ```json
 {
   "iss": "did:web:web3.storage",
-  "aud": "did:web:filecoin.web3.storage",
+  "aud": "did:key:agg...",
   "att": [{
     "with": "did:web:web3.storage",
-    "can": "piece/offer",
+    "can": "piece/add",
     "nb": {
       "piece": { "/": "commitment...car" }, /* commitment proof for piece */
-      "provider": "did:web:free.web3.storage", /* provider associated with space where content was added */
+      "group": "did:web:free.web3.storage", /* grouping for joining segments together into an aggregate */
     }
   }],
   "prf": [],
@@ -282,41 +291,39 @@ A storefront principal can invoke a capability to offer a piece to be aggregated
 }
 ```
 
-Aggregator MUST issue a signed receipt when piece is verified. Issued receipt MUST contain an [effect](https://github.com/ucan-wg/invocation/#7-effect) with a subsequent task (`.fx.join` field) that is run when piece is added to an aggregate and either succeeds (implying that aggregate was queued for being offered) or fails (with `error` describing the problem).
+Aggregator MUST issue a signed receipt to acknowledge the received request. Issued receipt MUST contain an [effect](https://github.com/ucan-wg/invocation/#7-effect) with a subsequent task (`.fx.join` field) that is run when piece is added to an aggregate and either succeeds (implying that aggregate was queued for being offered) or fails (with `error` describing the problem).
 
 ```json
 {
   "ran": "bafy...invocation",
   "out": {
     "ok": {
-      "status": "queued-for-aggregate"
+      "status": "queued"
     }
   },
   "fx": {
     "join": { "/": "bafy...dequeue" }
   },
   "meta": {},
-  "iss": "did:web:filecoin.web3.storage",
+  "iss": "did:key:agg...",
   "prf": []
 }
 ```
 
-See [`aggregate/arrange`](#aggregatearrange) section to see the subsequent task.
+When piece request to be added is dequeued, aggregator should invoke `piece/add` to include it in an aggregate.
 
-### `aggregate/arrange`
-
-When an Aggregator principal receives a `piece/offer` invocation from a Storefront Principal, an [Effect](https://github.com/ucan-wg/invocation/#7-effect) for this submission is created with join task to be performed asynchronously. See [schema](#aggregatearrange-schema).
+> `did:key:agg...` invokes capability from `did:key:agg...`
 
 ```json
 {
-  "iss": "did:web:filecoin.web3.storage",
-  "aud": "did:web:web3.storage",
+  "iss": "did:key:agg...",
+  "aud": "did:key:agg...",
   "att": [{
-    "with": "did:web:filecoin.web3.storage",
-    "can": "aggregate/arrange",
+    "with": "did:key:agg...",
+    "can": "piece/add",
     "nb": {
-      "aggregate": { "/": "commitment...aggregate-proof" }, /* commitment proof */
-      "piece": { "/": "commitment...piece-proof" } /* commitment proof */
+      "piece": { "/": "commitment...car" }, /* commitment proof for piece */
+      "group": "did:web:free.web3.storage", /* grouping for joining segments together into an aggregate */
     }
   }],
   "prf": [],
@@ -324,26 +331,25 @@ When an Aggregator principal receives a `piece/offer` invocation from a Storefro
 }
 ```
 
-Once this invocation is executed, a receipt is generated with the result of the task. Arranged aggregate for piece receipt looks like:
+Aggregator MUST issue a signed receipt with the result of the task. Arranged aggregate for piece receipt looks like:
 
 ```json
 {
   "ran": "bafy...arrange",
   "out": {
     "ok": {
-       "aggregate": { "/": "commitment...aggregate-proof" } /* commitment proof */
+        "status": "accepted",
+        "piece": { "/": "commitment...car" }, /* commitment proof for piece */
+        "aggregate": { "/": "commitment...aggregate-proof" } /* commitment proof */
     }
   },
-  "fx": {
-    "join": { "/": "bafy...dequeue-deal" }
-  },
   "meta": {},
-  "iss": "did:web:filecoin.web3.storage",
+  "iss": "did:key:agg...",
   "prf": []
 }
 ```
 
-If offered piece is invalid, details on failing pieces are also reported:
+If offered piece is invalid, reason is also reported:
 
 ```json
 {
@@ -354,18 +360,15 @@ If offered piece is invalid, details on failing pieces are also reported:
       "reason": "reasonCode",
     },
   },
-  "fx": {
-    "fork": []
-  },
   "meta": {},
-  "iss": "did:web:web3.storage",
+  "iss": "did:key:agg...",
   "prf": []
 }
 ```
 
-### `aggregate/offer`
+### `aggregate/add`
 
-An aggregator principal can invoke a capabilty to offer an aggregate that is ready to be included in Filecoin deal(s). See [schema](#aggregateoffer-schema).
+An aggregator principal can invoke a capabilty to add an aggregate that is ready to be included in Filecoin deal(s). See [schema](#aggregateadd-schema).
 
 > `did:web:filecoin.web3.storage` invokes capability from `did:web:spade.storage`
 
@@ -375,10 +378,14 @@ An aggregator principal can invoke a capabilty to offer an aggregate that is rea
   "aud": "did:web:spade.storage",
   "att": [{
     "with": "did:web:filecoin.web3.storage",
-    "can": "aggregate/offer",
+    "can": "aggregate/add",
     "nb": {
       "offer": { "/": "bafy...many-cars" }, /* dag-cbor CID with offer content */
-      "piece": { "/": "commitment...aggregate-proof" } /* commitment proof for aggregate */
+      "piece": { "/": "commitment...aggregate-proof" }, /* commitment proof for aggregate */
+      "deal": {
+        "tenantId": "web3.storage",
+        "label": "deal-label"
+      }
     }
   }],
   "prf": [],
@@ -386,9 +393,11 @@ An aggregator principal can invoke a capabilty to offer an aggregate that is rea
 }
 ```
 
-Invoking `aggregate/offer` capability submits an aggregate to a broker service for inclusion in one or more Filecoin deals. The `nb.piece` field represents the proof of the `piece` to be offered for the deal. It is a CID with its piece size encoded.
+Invoking `aggregate/add` capability submits an aggregate to a broker service for inclusion in one or more Filecoin deals.
 
-The `nb.offer` field represents a "Ferry" aggregate offer that is ready for a Filecoin deal. Its value is the DAG-CBOR CID that refers to a "Ferry" offer. It encodes a dag-cbor block with an array of entries representing all the pieces to include in the aggregated deal. This array MUST be sorted in the exact same order as they were used to compute the aggregate piece CID. This block MUST be included in the CAR file that transports the invocation. Its format is:
+The `nb.piece` field represents the proof of the `piece` to be offered for the deal. It is a CID with its piece size encoded. In addition, a Filecoin `nb.deal` contains the necessary fields for a Filecoin Deal proposal. More specifically, it MUST include `nb.deal.tenantId` that will allow broker to select from multiple wallets associated with the tenant and MAY include an arbitrary `nb.deal.label` chosen by the client.
+
+Finally, The `nb.offer` field represents a "Ferry" aggregate offer that is ready for a Filecoin deal. Its value is the DAG-CBOR CID that refers to a "Ferry" offer. It encodes a dag-cbor block with an array of entries representing all the pieces to include in the aggregated deal. This array MUST be sorted in the exact same order as they were used to compute the aggregate piece CID. This block MUST be included in the CAR file that transports the invocation. Its format is:
 
 ```json
 /* offers block as an array of piece CIDs, encoded as DAG-JSON (for readability) */
@@ -399,7 +408,7 @@ The `nb.offer` field represents a "Ferry" aggregate offer that is ready for a Fi
 ]
 ```
 
-Each entry of the decoded offers block, has all the necessary information for a Storage Provider to fetch and store a CAR file. It includes an array of Filecoin `piece` info required by Storage Providers. Out of band, Storefront will provide to Storage Providers a `src` HTTP URL to each CAR file in the offer.
+Each entry of the decoded offers block, has all the necessary information for a Storage Provider to fetch and store a CAR file. It includes an array of Filecoin `piece` info required by Storage Providers.
 
 Broker MUST issue a signed receipt to acknowledge the received request. Issued receipt MUST contain an [effect](https://github.com/ucan-wg/invocation/#7-effect) with a subsequent task (`.fx.join` field) that is run when submitted aggregate is processed and either succeeds (implying that aggregate was accepted and deals will be arranged) or fail (with `error` describing a problem with the aggregate).
 
@@ -420,18 +429,78 @@ Broker MUST issue a signed receipt to acknowledge the received request. Issued r
 }
 ```
 
-See [`offer/arrange`](#offerarrange) section to see the subsequent task.
+When aggregate request to be added is dequeued, broker should invoke `aggregate/add` to store it.
 
-### `aggregate/get`
-
-A Storefront principal can query state of accepted aggregate by invoking `aggregate/get` capability. See [schema](#aggregateget-schema).
-
-> `did:web:filecoin.web3.storage` invokes capability from `did:web:spade.storage`
+> `did:web:spade.storage` invokes capability from `did:web:spade.storage`
 
 ```json
 {
-  "iss": "did:web:filecoin.web3.storage",
+  "iss": "did:web:spade.storage",
   "aud": "did:web:spade.storage",
+  "att": [{
+    "with": "did:web:spade.storage",
+    "can": "aggregate/add",
+    "nb": {
+      "offer": { "/": "bafy...many-cars" }, /* dag-cbor CID with offer content */
+      "piece": { "/": "commitment...aggregate-proof" }, /* commitment proof for aggregate */
+      "deal": {
+        "tenantId": "web3.storage",
+        "label": "deal-label"
+      }
+    }
+  }],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+Broker MUST issue a signed receipt with the result of the task. Arranged aggregate receipt looks like:
+
+```json
+{
+  "ran": "bafy...invocation",
+  "out": {
+    "ok": {
+      "status": "accepted",
+      "piece": { "/": "commitment...aggregate-proof" } /* commitment proof */
+    }
+  },
+  "meta": {},
+  "iss": "did:web:spade.storage",
+  "prf": []
+}
+```
+
+If offered aggregate is invalid, details on failing pieces are also reported:
+
+```json
+{
+  "ran": "bafy...invocation",
+  "out": {
+    "error": {
+      "piece": { "/": "commitment...aggregate-proof" }, /* commitment proof */
+      "cause": [{
+        "piece": { "/": "commitment...car0" },
+        "reason": "reasonCode",
+      }],
+    },
+  },
+  "meta": {},
+  "iss": "did:web:spade.storage",
+  "prf": []
+}
+```
+
+### `chain/info`
+
+A Storefront principal can query state of accepted aggregate by invoking `chain/info` capability.
+
+> `did:web:web3.storage` invokes capability from `did:key:chain...`
+
+```json
+{
+  "iss": "did:web:web3.storage",
+  "aud": "did:web:chain...",
   "att": [{
     "with": "did:web:filecoin.web3.storage",
     "can": "aggregate/get",
@@ -475,91 +544,31 @@ Once this invocation is executed, a receipt is generated with the resulting aggr
 }
 ```
 
-### `offer/arrange`
-
-When a broker receives an `aggregate/offer` invocation from an Aggregator Principal, an [Effect](https://github.com/ucan-wg/invocation/#7-effect) for this submission is created with join task to be performed asynchronously. See [schema](#offerarrange-schema).
-
-```json
-{
-  "iss": "did:web:spade.storage",
-  "aud": "did:web:filecoin.web3.storage",
-  "att": [{
-    "with": "did:web:spade.storage",
-    "can": "offer/arrange",
-    "nb": {
-      "piece": { "/": "commitment...aggregate-proof" } /* commitment proof */
-    }
-  }],
-  "prf": [],
-  "sig": "..."
-}
-```
-
-Once this invocation is executed, a receipt is generated with the result of the task. Accepted aggregate receipt looks like:
-
-```json
-{
-  "ran": "bafy...arrange",
-  "out": {
-    "ok": {
-       "piece": { "/": "commitment...aggregate-proof" } /* commitment proof */
-    }
-  },
-  "fx": {
-    "fork": []
-  },
-  "meta": {},
-  "iss": "did:web:spade.storage",
-  "prf": []
-}
-```
-
-If offered aggregate is invalid, details on failing pieces are also reported:
-
-```json
-{
-  "ran": "bafy...invocation",
-  "out": {
-    "error": {
-      "piece": { "/": "commitment...aggregate-proof" }, /* commitment proof */
-      "cause": [{
-        "piece": { "/": "commitment...car0" },
-        "reason": "reasonCode",
-      }],
-    },
-  },
-  "fx": {
-    "fork": []
-  },
-  "meta": {},
-  "iss": "did:web:spade.storage",
-  "prf": []
-}
-```
-
 ## Schema
 
 ### Base types
 
 ```ipldsch
+type FilecoinCapability enum {
+  FilecoinAdd "filecoin/add"
+} representation inline {
+  discriminantKey "can"
+}
+
 type PieceCapability enum {
   PieceAdd "piece/add"
-  PieceVerify "piece/verify"
-  PieceOffer "piece/offer"
 } representation inline {
   discriminantKey "can"
 }
 
 type AggregateCapability enum {
-  AggregateArrange "aggregate/arrange"
-  AggregateOffer "aggregate/offer"
-  AggregateGet "aggregate/get"
+  AggregateAdd "aggregate/add"
 } representation inline {
   discriminantKey "can"
 }
 
-type OfferCapability union {
-  OfferArrange "offer/arrange"
+type ChainCapability enum {
+  ChainInfo "chain/info"
 } representation inline {
   discriminantKey "can"
 }
@@ -568,14 +577,31 @@ type PieceRef struct {
   piece PieceCid
 }
 
-type URL string
 type AgentDID string
 type StorefrontDID string
 type AggregatorDID string
 type BrokerDID string
+type ChainDID string
+
 # from a fr32-sha2-256-trunc254-padded-binary-tree multihash
 type PieceCid Link
-type CarCid Link
+type ContentCid Link
+```
+
+### `filecoin/add` schema
+
+```ipldsch
+type FilecoinAdd struct {
+  with AgentDID
+  nb FilecoinAddDetail
+}
+
+type FilecoinAddDetail struct {
+  # CID of file previously added to resource space
+  content ContentCid
+  # Piece as Filecoin Piece with padding
+  piece PieceCid
+}
 ```
 
 ### `piece/add` schema
@@ -587,95 +613,40 @@ type PieceAdd struct {
 }
 
 type PieceAddDetail struct {
-  # link of the stored CAR file associated with this piece
-  link CarCid
   # Piece as Filecoin Piece with padding
   piece PieceCid
+  # grouping for joining segments together into an aggregate
+  group string
 }
 ```
 
-### `piece/verify` schema
+### `aggregate/add` schema
 
 ```ipldsch
-type PieceVerify struct {
+type AggregateAdd struct {
   with StorefrontDID
-  nb PieceVerifyDetail
+  nb AggregateAddDetail
 }
 
-type PieceVerifyDetail struct {
-  # link of the stored CAR file associated with this piece
-  link CarCid
-  # Piece as Filecoin Piece with padding
-  piece PieceCid
-}
-```
-
-### `piece/offer` schema
-
-```ipldsch
-type PieceOffer struct {
-  with StorefrontDID
-  nb PieceOfferDetail
-}
-
-type PieceOfferDetail struct {
-  # Piece as Filecoin Piece with padding
-  piece PieceCid
-  # Provider associated with space where content was added 
-  provider string
-}
-```
-
-### `aggregate/arrange` schema
-
-```ipldsch
-type AggregateArrange struct {
-  with BrokerDID
-  nb AggregateArrangeDetail
-}
-
-type AggregateArrangeDetail struct {
-  # Piece as Filecoin Piece with padding
-  piece PieceCid
-  # Piece as Aggregate of CARs with padding
-  aggregate PieceCid
-}
-```
-
-### `aggregate/offer` schema
-
-```ipldsch
-type AggregateOffer struct {
-  with StorefrontDID
-  nb AggregateOfferDetail
-}
-
-type AggregateOfferDetail struct {
+type AggregateAddDetail struct {
   # Contains each individual piece within Aggregate piece
   offer &Offer
   # Piece as Aggregate of CARs with padding
   piece PieceCid
+  # Fields to create a contract with a Storage Provider for aggregate
+  deal DealProposal
+}
+
+# @see https://github.com/filecoin-project/go-state-types/blob/ff2ed169ff566458f2acd8b135d62e8ca27e7d0c/builtin/v9/market/deal.go#L201-L221
+# A subset of the deal proposal items required by broker to facilitate the contract to be created
+type DealProposal struct {
+  # identifier of the tenant that added pieces for the aggregate
+  tenantId string
+  # Label is an arbitrary client chosen label to apply to the deal
+  label string
 }
 
 type Offer [PieceCid]
-```
-
-### `aggregate/get` schema
-
-```ipldsch
-type AggregateGet struct {
-  with StorefrontDID
-  nb PieceRef
-}
-```
-
-### `offer/arrange` schema
-
-```ipldsch
-type OfferArrange struct {
-  with BrokerDID
-  nb PieceRef
-}
 ```
 
 [`did:web`]: https://w3c-ccg.github.io/did-method-web/

--- a/w3-aggregation.md
+++ b/w3-aggregation.md
@@ -46,13 +46,13 @@ An Aggregator facilitates data storage into Filecoin deals by aggregating smalle
 
 ### Broker
 
-A _Broker_ is a type of [principal] identified that arranges deals for the aggregates submitted by _Storefront_.
+A _Broker_ is a type of [principal] that arranges deals for the aggregates submitted by _Storefront_.
 
 # Protocol
 
 ## Overview
 
-A Storefront is the entry point for user/application data into web3. It will act on behalf of users to move data around into different storage points. One of the key storage presences may be Filecoin Storage Providers. Storefront is able to ingest files of arbitrary sizes, while Storage Providers are looking for storing larger pieces, rather than small pieces. Accordingly, the aggregator is responsible for aggregating multiple smaller pieces into a bigger one that can be stored by Storage Providers.
+A Storefront is the entry point for user/application data into web3. It will act on behalf of users and move data around into different storage points. One of the key storage presences may be Filecoin Storage Providers. Storefront is able to ingest files of arbitrary sizes, while Storage Providers are looking for storing larger pieces, rather than small pieces. Accordingly, the aggregator is responsible for aggregating multiple smaller pieces into a bigger one that can be stored by Storage Providers.
 
 ### Authorization
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -43,7 +43,8 @@ A Storefront facilitates data storage services to applications and users, gettin
 
 An _Aggregator_ is a type of [principal] identified by a `did:key` identifier.
 
-An Aggregator facilitates data storage into Filecoin deals by aggregating smaller data (Filecoin Pieces) into a larger piece that can effectively be stored with a Filecoin Storage Provider.
+An Aggregator facilitates data storage into Filecoin deals by aggregating smaller data (Filecoin Pieces) into a larger piece that can effectively be stored with a Filecoin Storage Provider using [Verifiable Data Aggregation
+](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0058.md).
 
 ### Dealer
 
@@ -342,7 +343,8 @@ Aggregator MUST issue a signed receipt with the result of the task. Arranged agg
   "out": {
     "ok": {
         "piece": { "/": "commitment...car" }, /* commitment proof for piece */
-        "aggregate": { "/": "commitment...aggregate-proof" } /* commitment proof */
+        "aggregate": { "/": "commitment...aggregate-proof" }, /* commitment proof */
+        "path": "path-between-root-aggregate-and-piece"
     }
   },
   "meta": {},

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -30,7 +30,7 @@ There are several roles in the authorization flow:
 | ----------- | ----------- |
 | Storefront  | [Principal] identified by [`did:web`] identifier, representing a storage API like web3.storage |
 | Aggregator  | [Principal] identified by `did:key` identifier, representing a storage aggregator like w3filecoin |
-| Broker      | [Principal] identified by `did:key` identifier that arranges filecoin deals with storage providers like spade |
+| Broker      | [Principal] identified by `did:key` identifier that arranges filecoin deals with storage providers. e.g. Spade |
 | Chain       | [Principal] identified by `did:key` identifier that tracks the filecoin chain |
 
 ### Storefront
@@ -67,9 +67,9 @@ Broker MUST have an authorization mechanism for allowed Storefront principals (e
 
 When a Storefront's user (agent) intends to store a given content into a Filecoin Storage Provider, its proof SHOULD be computed (commonly known as Filecoin Piece) by the client and added to the Storefront. Note that Storefront MAY decide to compute the piece without waiting for an Agent to store received content into a Filecoin deal, or verify the agent claimed one. Storefront MUST acknowledge a request by issuing a signed receipt.
 
-Once a Storefront receives the offer of a piece by an agent, the piece gets queued for verification. A receipt is created to proof the transition of the added piece state from `null` into `queued` for verification. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it has no effect.
+Once a Storefront receives the offer of a piece by an agent, the piece gets queued for verification. A receipt is created to proof the transition of the added piece state from `null` into `queued` for verification. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it is a nop.
 
-This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the piece was accepted) or fails, so that its receipt COULD be looked up using it.
+This receipt MUST have a link to a followup task (using `.fx.join` field) that either succeeds (if the piece was accepted) or fails, so that its receipt MAY be looked up using it.
 
 After a storefront dequeues the piece and verifies it, a receipt is created to proof the transition of the aggregate state from `queued` into `accepted` or `rejected`. This receipt MUST have link to a followup task (using `.fx.join` field) with `piece/add`.
 
@@ -91,11 +91,11 @@ sequenceDiagram
 
 Once a Storefront receives a valid piece, it MAY be offered for aggregation, so that it makes its way into a Storage Provider. Aggregation MAY be handled asynchronously, therefore the Aggregator MUST acknowledge a request by issuing a signed receipt.
 
-Once an Aggregator successfully receives a piece offer, the piece gets queued for aggregation. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it has no effect.
+Once an Aggregator successfully receives a piece offer, the piece gets queued for aggregation. A receipt is created to prove the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it is a nop.
 
-This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the piece was added into an aggregate) or fails, so that its receipt COULD be looked up using it.
+This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the piece was added into an aggregate) or fails, so that its receipt MAY be looked up using it.
 
-After an aggregator dequeues the piece, it will be included into an aggregate to be offered for Storage Providers. A receipt is created to proof the transition of the aggregate state from `queued` into `accepted` or `rejected`. If successful, a inclusion proof should also be provided.
+After an aggregator dequeues the piece, it will be included into an aggregate to be offered for Storage Providers. A receipt is created to proof the transition of the aggregate state from `queued` into `accepted` or `rejected`. If successful, a inclusion proof MUST also be provided.
 
 ```mermaid
 sequenceDiagram
@@ -115,7 +115,7 @@ sequenceDiagram
 
 When the Aggregator has enough content to fulfill an aggregate (each broker MAY have different requirements), a Filecoin deal for an aggregate MAY be requested by an `aggregate/offer` invocation. Deal negotiations with Filecoin Storage Providers MAY be handled out of band. Broker MUST acknowledge a request by issuing a signed receipt.
 
-Once a Broker successfully receives the offer of an aggregate, the aggregate gets queued for deals with Storage Providers. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for an aggregate that is already `queued` or `accepted`, it has no effect.
+Once a Broker successfully receives the offer of an aggregate, the aggregate gets queued for deals with Storage Providers. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for an aggregate that is already `queued` or `accepted`, it is a nop.
 
 This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the aggregate was added into a deal) or fails (if the aggregate was determined to be invalid) so that its receipt COULD be looked up using it.
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -380,10 +380,8 @@ An aggregator principal can invoke a capabilty to add an aggregate that is ready
     "nb": {
       "pieces": { "/": "bafy...many-cars" }, /* dag-cbor CID with content pieces */
       "aggregate": { "/": "bafk...aggregate-proof" }, /* commitment proof for aggregate */
-      "deal": {
-        "tenantId": "did:web:web3.storage",
-        "label": "deal-label"
-      }
+      "storefront": "did:web:web3.storage", /* storefront responsible for invocation */
+      "label": "deal-label"
     }
   }],
   "prf": [],
@@ -634,15 +632,10 @@ type DealAddDetail struct {
   # Piece as Aggregate of CARs with padding
   aggregate PieceCid
   # Fields to create a contract with a Storage Provider for aggregate
-  deal DealProposal
-}
-
-# @see https://github.com/filecoin-project/go-state-types/blob/ff2ed169ff566458f2acd8b135d62e8ca27e7d0c/builtin/v9/market/deal.go#L201-L221
-# A subset of the deal proposal items required by broker to facilitate the contract to be created
-type DealProposal struct {
-  # identifier of the tenant that added pieces for the aggregate
-  tenantId string
+  # storefront responsible for invocation
+  storefront string
   # Label is an arbitrary client chosen label to apply to the deal
+  # @see https://github.com/filecoin-project/go-state-types/blob/ff2ed169ff566458f2acd8b135d62e8ca27e7d0c/builtin/v9/market/deal.go#L201-L221
   label string
 }
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -61,13 +61,13 @@ A Storefront is web2 to web3 bridge. It ingests user/application data through a 
 
 ### Authorization
 
-Out-of-band registered Storefronts MUST use UCAN based authotization mechanisms to interact with Aggregators, Dealers and Chain Trackers. In the future protocol for registering Storefronts might be introduced.
+Out-of-band registered Storefronts MUST use UCAN based authorization mechanisms to interact with Aggregators, Dealers and Chain Trackers. In the future protocol for registering Storefronts might be introduced.
 
 For example, an Aggregator can authorize invocations from `did:web:web3.storage` by validating the signature is from the DID. This way, it allows web3.storage to rotate keys and/or re-delegate access without having to coordinate with the Aggregator.
 
 ### Storefront receives a Filecoin piece
 
-The Storefront MUST submit content for aggregation by it's piece CID (CommP) that MAY be computed from content by a trusted actor. Storefront MUST provide a capability that can be used to submit a piece to be replicated by (Filecoin) Storage Providers. It may be invoked by Storefront client or delegated to a hired third party, ether way Storefront MUST acknowledge request by issuing a signed receipt. Storefront MAY decide to verify submitted piece prior to aggregation. Storefront MAY also operate trusted actor that computes and submits pieces on content upload.
+The Storefront MUST submit content for aggregation by it's piece CID that MAY be computed from content by a trusted actor. Storefront MUST provide a capability that can be used to submit a piece to be replicated by (Filecoin) Storage Providers. It may be invoked by Storefront client or delegated to a hired third party, ether way Storefront MUST acknowledge request by issuing a signed receipt. Storefront MAY decide to verify submitted piece prior to aggregation. Storefront MAY also operate trusted actor that computes and submits pieces on content upload.
 
 Once a Storefront receives the offer for a piece, it is queued for verification. A receipt is issued to proof the transition of the added piece state from `null` into `queued` for verification.
 
@@ -248,7 +248,7 @@ Storefront MUST issue a signed receipt to communicate the response for the reque
 }
 ```
 
-See [`piece/add`](#pieceadd) section to see the subsequent task.
+See [`aggregate/add`](#aggregateadd) section to see the subsequent task.
 If the added piece is invalid, details on failing reason is also reported:
 
 ```json

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -67,7 +67,7 @@ Broker MUST have an authorization mechanism for allowed Storefront principals (e
 
 When a Storefront's user (agent) intends to store a given content into a Filecoin Storage Provider, its proof SHOULD be computed (commonly known as Filecoin Piece) by the client and added to the Storefront. Note that Storefront MAY decide to compute the piece without waiting for an Agent to store received content into a Filecoin deal, or verify the agent claimed one. Storefront MUST acknowledge a request by issuing a signed receipt.
 
-Once a Storefront receives the offer of a piece by an agent, the piece gets queued for verification. A receipt is created to proof the transition of the added piece state from `null` into `queued` for verification. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it is a nop.
+Once a Storefront receives the offer of a piece by an agent, the piece gets queued for verification. A receipt is created to proof the transition of the added piece state from `null` into `queued` for verification. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it is a NOP.
 
 This receipt MUST have a link to a followup task (using `.fx.join` field) that either succeeds (if the piece was accepted) or fails, so that its receipt MAY be looked up using it.
 
@@ -91,7 +91,7 @@ sequenceDiagram
 
 Once a Storefront receives a valid piece, it MAY be offered for aggregation, so that it makes its way into a Storage Provider. Aggregation MAY be handled asynchronously, therefore the Aggregator MUST acknowledge a request by issuing a signed receipt.
 
-Once an Aggregator successfully receives a piece offer, the piece gets queued for aggregation. A receipt is created to prove the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it is a nop.
+Once an Aggregator successfully receives a piece offer, the piece gets queued for aggregation. A receipt is created to prove the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for a piece that is already `queued` or `accepted`, it is a NOP.
 
 This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the piece was added into an aggregate) or fails, so that its receipt MAY be looked up using it.
 
@@ -115,7 +115,7 @@ sequenceDiagram
 
 When the Aggregator has enough content to fulfill an aggregate (each broker MAY have different requirements), a Filecoin deal for an aggregate MAY be requested by an `aggregate/offer` invocation. Deal negotiations with Filecoin Storage Providers MAY be handled out of band. Broker MUST acknowledge a request by issuing a signed receipt.
 
-Once a Broker successfully receives the offer of an aggregate, the aggregate gets queued for deals with Storage Providers. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for an aggregate that is already `queued` or `accepted`, it is a nop.
+Once a Broker successfully receives the offer of an aggregate, the aggregate gets queued for deals with Storage Providers. A receipt is created to proof the transition of the offered aggregate state from `null` into `queued`. It is worth mentioning that if an offer is for an aggregate that is already `queued` or `accepted`, it is a NOP.
 
 This receipt MUST have link to a followup task (using `.fx.join` field) that either succeeds (if the aggregate was added into a deal) or fails (if the aggregate was determined to be invalid) so that its receipt COULD be looked up using it.
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -499,7 +499,7 @@ A Storefront principal can query state of an aggregate by invoking `chain-tracke
   "aud": "did:web:chain-tracker...",
   "att": [{
     "with": "did:web:web3.storage",
-    "can": "chain/info",
+    "can": "chain-tracker/info",
     "nb": {
       "piece": { "/": "commitment...aggregate-proof" } /* commitment proof */
     }

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -117,7 +117,7 @@ sequenceDiagram
 
 ### Aggregator offers dealer an aggregate
 
-When the Aggregator has enough content pieces to build a qualified aggregate (dealers MAY impose different requirements), it MUST submit a Filecoin deal for the aggregate to a Dealer using `deal/offer` invocation. Dealer MUST issue signed receipt acknowledging submission, actual deal negotiation with Filecoin Storage Providers MAY carry out of band. 
+When the Aggregator has enough content pieces to build a qualified aggregate (dealers MAY impose different requirements), it MUST submit a Filecoin deal for the aggregate to a Dealer using `deal/offer` invocation. Dealer MUST issue signed receipt acknowledging submission, actual deal negotiation with Filecoin Storage Providers MAY carry out of band.
 
 Once a Dealer receives an aggregate offer it is queued for negotiations with Storage Providers. Issued receipt is a proofs transition of the (offered aggregate) state from `null` into `queued`. If Dealer receives request with an aggregate already in pipeline it MUST simply reissue receipt with a same result and effects as the original request.
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -280,7 +280,8 @@ A storefront principal can invoke a capability to offer a piece to be aggregated
     "can": "piece/add",
     "nb": {
       "piece": { "/": "commitment...car" }, /* commitment proof for piece */
-      "group": "did:web:free.web3.storage", /* grouping for joining segments together into an aggregate */
+      "space": "did:web:web3.storage",      /* space where all segments are joined together */
+      "group": "did:web:free.web3.storage", /* grouping of joining segments into an aggregate */
     }
   }],
   "prf": [],
@@ -320,7 +321,8 @@ When piece request to be added is dequeued, aggregator should invoke `piece/add`
     "can": "piece/add",
     "nb": {
       "piece": { "/": "commitment...car" }, /* commitment proof for piece */
-      "group": "did:web:free.web3.storage", /* grouping for joining segments together into an aggregate */
+      "space": "did:web:web3.storage",      /* space where all segments are joined together */
+      "group": "did:web:free.web3.storage", /* grouping of joining segments into an aggregate */
     }
   }],
   "prf": [],
@@ -612,7 +614,9 @@ type PieceAdd struct {
 type PieceAddDetail struct {
   # Piece as Filecoin Piece with padding
   piece PieceCid
-  # grouping for joining segments together into an aggregate
+  # space where all segments are joined together
+  space string
+  # grouping for joining segments into an aggregate (subset of space)
   group string
 }
 ```

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -1,4 +1,4 @@
-# CAR Aggregation Protocol
+# W3 Filecoin Protocol
 
 ![status:wip](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square)
 
@@ -80,7 +80,6 @@ sequenceDiagram
 
     Agent->>Storefront: invoke `filecoin/add`<br>with:`did:key:aSpace`
     Note left of Storefront: Request piece to be added to filecoin deal
-    Storefront->>Storefront: invoke `filecoin/add`<br>with:`did:key:filecoinQueue`
     activate Storefront
     Storefront-->>Agent: receipt issued as `queued`
     Storefront->>Storefront: invoke `filecoin/add`<br>with:`did:web:web3.storage`
@@ -105,7 +104,6 @@ sequenceDiagram
 
     Storefront->>Aggregator: invoke `piece/add`<br>with:`did:web:web3.storage`
     Note left of Aggregator: Request piece to be included in aggregate
-    Aggregator->>Aggregator: invoke `piece/add`<br>with:`did:key:pieceQueue`
     activate Aggregator
     Aggregator-->>Storefront: receipt issued as `queued`
     Aggregator->>Aggregator: invoke `piece/add`<br>with:`did:key:agg...`
@@ -132,7 +130,6 @@ sequenceDiagram
 
     Aggregator->>Broker: invoke `aggregate/add`<br>with:`did:key:agg...`
     Note left of Broker: Request aggregate to be queued for deal proposal
-    Broker->>Broker: invoke `aggregate/add`<br>with:`did:key:aggregateQueue`
     activate Broker
     Broker-->>Aggregator: receipt issued as `queued`
     Broker->>Broker: invoke `aggregate/add`<br>with:`did:key:brk...`

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -252,7 +252,6 @@ If the added piece is invalid, details on failing reason is also reported:
   "ran": "bafy...invocation",
   "out": {
     "error": {
-      "piece": { "/": "commitment...car" }, /* commitment proof for piece */
       "reason": "reasonCode",
     },
   },
@@ -355,7 +354,6 @@ If offered piece is invalid, reason is also reported:
   "ran": "bafy...invocation",
   "out": {
     "error": {
-      "piece": { "/": "commitment...car" }, /* commitment proof for piece */
       "reason": "reasonCode",
     },
   },

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -280,7 +280,7 @@ A storefront principal can invoke a capability to offer a piece to be aggregated
     "can": "piece/add",
     "nb": {
       "piece": { "/": "commitment...car" }, /* commitment proof for piece */
-      "space": "did:web:web3.storage",      /* space where all segments are joined together */
+      "storefront": "did:web:web3.storage", /* storefront responsible for invocation */
       "group": "did:web:free.web3.storage", /* grouping of joining segments into an aggregate */
     }
   }],
@@ -614,8 +614,8 @@ type PieceAdd struct {
 type PieceAddDetail struct {
   # Piece as Filecoin Piece with padding
   piece PieceCid
-  # space where all segments are joined together
-  space string
+  # storefront responsible for invocation
+  storefront string
   # grouping for joining segments into an aggregate (subset of space)
   group string
 }


### PR DESCRIPTION
Based on my previous proposal to @Gozala that @Gozala covered in https://github.com/web3-storage/RFC/pull/2

Changes the aggregation spec introducing new capabilities and a new role. Main reasoning for this change is the new distinction between Storefront and Aggregator (previously had same identity), where a Storefront (web3.storage, nftstorage)  will receive/compute Filecoin pieces (from received CAR files) and offer them to an Aggregator (w3filecoin). The aggregator's role is to put multiple pieces together to offer a large piece (aggregate) to a Broker (spade-proxy).

Per the above, the new invocations added are described in https://www.notion.so/2023-07-26-aggregation-protocol-contract-sign-and-report-API-12b4a7f0e92f4b789c331322e2629817

Renamed spec from aggregation to w3 filecoin given the context increased from aggregation to accommodate new requirements

Note that `list`, will be added later on