### PR TITLE
feat: propose `admin/upload/inspect` and `admin/store/inspect` capabilities

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -1,4 +1,5 @@
 CIDs
+CID's
 Hardt
 Holmgren
 JSON

--- a/w3-admin.md
+++ b/w3-admin.md
@@ -20,8 +20,8 @@ to administrative users by creating delegations signed with the service signer's
   - [`consumer/get`](#consumerget)
   - [`customer/get`](#customerget)
   - [`subscription/get`](#subscriptionget)
-  - [`trace/upload/get`](#traceuploadget)
-  - [`trace/store/get`](#tracestoreget)
+  - [`trace/upload/add`](#traceuploadadd)
+  - [`trace/store/add`](#tracestoreadd)
 
 ## Language
 
@@ -151,7 +151,7 @@ export const get = capability({
 })
 ```
 
-### `trace/upload/get`
+### `trace/upload/add`
 
 Get information about a content CID. This does not return the actual data identified by the CID, just metadata our
 system tracks, e.g. the spaces the content identified by a given CID has been uploaded to and the dates the uploads happened.
@@ -171,7 +171,7 @@ with the date it was uploaded.
 }
 ```
 
-### `trace/store/get`
+### `trace/store/add`
 
 Get information about a shard (i.e., a CAR that contains part of an upload) CID. This
 does not return the actual data identified by the CID, just metadata our system tracks,

--- a/w3-admin.md
+++ b/w3-admin.md
@@ -20,7 +20,8 @@ to administrative users by creating delegations signed with the service signer's
   - [`consumer/get`](#consumerget)
   - [`customer/get`](#customerget)
   - [`subscription/get`](#subscriptionget)
-  - [`cid/get`](#cidget)
+  - [`root/get`](#rootget)
+  - [`shard/get`](#shardget)
 
 ## Language
 
@@ -153,8 +154,7 @@ export const get = capability({
 ### `root/get`
 
 Get information about an upload root CID. This does not return the actual data identified by the CID, just metadata our
-system tracks, e.g. the spaces the content identified by a given CID has been uploaded to and the 
-dates the uploads happened.
+system tracks, e.g. the spaces the content identified by a given CID has been uploaded to and the dates the uploads happened.
 
 #### inputs
 
@@ -173,7 +173,7 @@ with the date it was uploaded.
 
 ### `shard/get`
 
-Get information about a shard (ie, a CAR that contains part of an upload) CID. This
+Get information about a shard (i.e., a CAR that contains part of an upload) CID. This
 does not return the actual data identified by the CID, just metadata our system tracks,
 e.g. the spaces the CAR identified by a given CID has been stored in and the date it was stored.
 

--- a/w3-admin.md
+++ b/w3-admin.md
@@ -150,9 +150,9 @@ export const get = capability({
 })
 ```
 
-### cid/get
+### `root/get`
 
-Get information about a CID. This does not return the actual data identified by the CID, just metadata our
+Get information about an upload root CID. This does not return the actual data identified by the CID, just metadata our
 system tracks, e.g. the spaces the content identified by a given CID has been uploaded to and the 
 dates the uploads happened.
 
@@ -162,12 +162,32 @@ dates the uploads happened.
 
 #### returns
 
-The return type currently consists of two lists: "uploads" and "stores". These lists correspond to 
-the `upload/*` and `store/*` capabilities described in the [storage and upload protocol](./w3-store.md).
+The `uploads` property will be a list of spaces the given root CID's content has been uploaded to, along
+with the date it was uploaded.
 
 ```typescript
 {
-  uploads: {space: SpaceDID, insertedAt: Date}[]
-  stores: {space: SpaceDID, insertedAt: Date}[]
+  uploads: Array<{space: SpaceDID, insertedAt: Date}>
+}
+```
+
+### `shard/get`
+
+Get information about a shard (ie, a CAR that contains part of an upload) CID. This
+does not return the actual data identified by the CID, just metadata our system tracks,
+e.g. the spaces the CAR identified by a given CID has been stored in and the date it was stored.
+
+#### inputs
+
+`cid: CID`
+
+#### returns
+
+The `stores` property will be a list of spaces the specified shard was stored in, along with the date on
+which it was stored.
+
+```typescript
+{
+  stores: Array<{space: SpaceDID, insertedAt: Date}>
 }
 ```

--- a/w3-admin.md
+++ b/w3-admin.md
@@ -20,8 +20,8 @@ to administrative users by creating delegations signed with the service signer's
   - [`consumer/get`](#consumerget)
   - [`customer/get`](#customerget)
   - [`subscription/get`](#subscriptionget)
-  - [`root/get`](#rootget)
-  - [`shard/get`](#shardget)
+  - [`trace/upload/get`](#traceuploadget)
+  - [`trace/store/get`](#tracestoreget)
 
 ## Language
 
@@ -151,14 +151,14 @@ export const get = capability({
 })
 ```
 
-### `root/get`
+### `trace/upload/get`
 
-Get information about an upload root CID. This does not return the actual data identified by the CID, just metadata our
+Get information about a content CID. This does not return the actual data identified by the CID, just metadata our
 system tracks, e.g. the spaces the content identified by a given CID has been uploaded to and the dates the uploads happened.
 
 #### inputs
 
-`cid: CID`
+`root: CID`
 
 #### returns
 
@@ -171,7 +171,7 @@ with the date it was uploaded.
 }
 ```
 
-### `shard/get`
+### `trace/store/get`
 
 Get information about a shard (i.e., a CAR that contains part of an upload) CID. This
 does not return the actual data identified by the CID, just metadata our system tracks,
@@ -179,7 +179,7 @@ e.g. the spaces the CAR identified by a given CID has been stored in and the dat
 
 #### inputs
 
-`cid: CID`
+`link: CID`
 
 #### returns
 

--- a/w3-admin.md
+++ b/w3-admin.md
@@ -20,8 +20,8 @@ to administrative users by creating delegations signed with the service signer's
   - [`consumer/get`](#consumerget)
   - [`customer/get`](#customerget)
   - [`subscription/get`](#subscriptionget)
-  - [`trace/upload/add`](#traceuploadadd)
-  - [`trace/store/add`](#tracestoreadd)
+  - [`admin/upload/inspect`](#adminuploadinspect)
+  - [`admin/store/inspect`](#adminstoreinspect)
 
 ## Language
 
@@ -151,7 +151,7 @@ export const get = capability({
 })
 ```
 
-### `trace/upload/add`
+### `admin/upload/inspect`
 
 Get information about a content CID. This does not return the actual data identified by the CID, just metadata our
 system tracks, e.g. the spaces the content identified by a given CID has been uploaded to and the dates the uploads happened.
@@ -171,7 +171,7 @@ with the date it was uploaded.
 }
 ```
 
-### `trace/store/add`
+### `admin/store/inspect`
 
 Get information about a shard (i.e., a CAR that contains part of an upload) CID. This
 does not return the actual data identified by the CID, just metadata our system tracks,

--- a/w3-admin.md
+++ b/w3-admin.md
@@ -20,6 +20,7 @@ to administrative users by creating delegations signed with the service signer's
   - [`consumer/get`](#consumerget)
   - [`customer/get`](#customerget)
   - [`subscription/get`](#subscriptionget)
+  - [`cid/get`](#cidget)
 
 ## Language
 
@@ -147,4 +148,26 @@ export const get = capability({
     )
   },
 })
+```
+
+### cid/get
+
+Get information about a CID. This does not return the actual data identified by the CID, just metadata our
+system tracks, e.g. the spaces the content identified by a given CID has been uploaded to and the 
+dates the uploads happened.
+
+#### inputs
+
+`cid: CID`
+
+#### returns
+
+The return type currently consists of two lists: "uploads" and "stores". These lists correspond to 
+the `upload/*` and `store/*` capabilities described in the [storage and upload protocol](./w3-store.md).
+
+```typescript
+{
+  uploads: {space: SpaceDID, insertedAt: Date}[]
+  stores: {space: SpaceDID, insertedAt: Date}[]
+}
 ```


### PR DESCRIPTION
At a high level, these are designed to enable administrators like @dchoi27 to figure out which space a given CID is associated with.

Problem CIDs come to us from a variety of sources - sometimes they are content CIDs that correspond to a particular `upload/add` invocation and sometimes they are "shard" CIDs that identify one of the CARs stored using `store/add` that make up the shards of a larger upload. `admin/upload/inspect` returns information about the upload and `admin/store/inspect` returns information about particular shards, so given an unknown CID administrators should check both.