### PR TITLE
feat: add `store/get` & `upload/get` capabilities

### DIFF
--- a/w3-store.md
+++ b/w3-store.md
@@ -418,7 +418,7 @@ The `with` resource URI must be set to the DID of the space to get the upload me
 
 #### Caveats
 
-The `root` caveat must contain the root CID of the data item to remove.
+The `root` caveat must contain the root CID of the item to get metadata for.
 
 | `field`   | `value`                           | `required?` | `context`                                                     |
 | --------- | --------------------------------- | ----------- | ------------------------------------------------------------- |

--- a/w3-store.md
+++ b/w3-store.md
@@ -408,7 +408,7 @@ interface UploadAddResponse {
 
 The `upload/get` capability can be invoked to get metadata about an upload from a [space](#spaces).
 
-This may be used to check for inclusion, or to get the set of CAR shards associated with a root cid.
+This may be used to check for inclusion, or to get the set of CAR shards associated with a root CID.
 
 The `with` resource URI must be set to the DID of the space to get the upload metadata from.
 


### PR DESCRIPTION
These capabilities are intended for checking inclusion, or getting the additional properties we store. This will allow clients to verify all the shards for an upload have been removed before removing an upload.

## `store/get` delegation

```js
{
  can: "store/get",
  with: "did:key:abc...",
  nb: {
    link: "bag...",
  }
}
```

### Response

Error if `link` shard cid is not in space or...

```ts
interface StoreListItem {
  /** CID of the stored CAR. */
  link: string

  /** Size in bytes of the stored CAR */
  size: number

  /** Link to a related CAR, used for sharded uploads */
  origin?: string,

  /** ISO-8601 timestamp when CAR was added to the space */
  insertedAt: string,
}
```

## `upload/get` delegation

```js
{
  can: "upload/get",
  with: "did:key:abc...",
  nb: {
    root: "bafyabc..."
  }
}
```

### Response

`Error` if root is not in uploads for space or...

```ts
interface UploadListItem {
  /** Root CID of the uploaded data item. */
  root: string

  /** CIDs of CARs that contain the complete DAG for the uploaded data item. */
  shards: string[]

  /** ISO-8601 timestamp when the upload was added to the space. */
  insertedAt: string,

  /** ISO-8601 timestamp when the upload entry was last modified. */
  updatedAt: string,
}
```

---

see also: https://github.com/web3-storage/w3up/pull/942

License: MIT