### PR TITLE
fix: filecoin spec aggregate accept receipt type

### DIFF
--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -264,6 +264,11 @@ This task is effectively a shortcut allowing an observer to find out the result 
   "ran": "bafy...filAccept",
   "out": {
     "ok": {
+      /* commitment proof for piece */
+      "piece": { "/": "commitment...car" },
+      /* commitment proof for aggregate */
+      "aggregate": { "/": "commitment...aggregate" },
+      /** inclusion proof for piece */
       "inclusion": {
         "tree": {
           "path": [
@@ -279,9 +284,12 @@ This task is effectively a shortcut allowing an observer to find out the result 
           "at": 7
         }
       },
-      "auxDataType": 0,
-      "auxDataSource": {
-        "dealID": 1245
+      /** deal type */
+      "aux": {
+        "dataType": 0,
+        "dataSource": {
+          "dealID": 1245
+        }
       }
     }
   }

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -520,23 +520,10 @@ The [Dealer] MUST issue a receipt for the [`aggregate/accept`] task once it arra
   "ran": "bafy...aggregateAccept",
   "out": {
     "ok": {
-      "inclusion": {
-        "tree": {
-          "path": [
-            "bafk...root",
-            "bafk...parent",
-            "bafk...child",
-            "bag...car"
-          ],
-          "at": 1
-        },
-        "index": {
-          "path": [/** ... */],
-          "at": 7
-        }
-      },
-      "auxDataType": 0,
-      "auxDataSource": {
+      /* commitment proof for aggregate */
+      "aggregate": { "/": "bafk...aggregate-proof" },
+      "dataType": 0,
+      "dataSource": {
         "dealID": 1245
       }
     }


### PR DESCRIPTION
Fixes aggregate/accept receipt:

1. inclusion proof was wrongly here. It should only be in `piece/accept` because it is piece specific proof within an aggregate
2. added `aggregate` in receipt to be coherent with other receipts for `*/accept`

Fixes filecoin/accept receipt:
1. added `piece` and `aggregate` in receipt to be coherent with other receipts for `*/accept`
2. swaped `aux` to be a property per https://github.com/web3-storage/w3up/pull/974#discussion_r1368342534