### PR TITLE
docs: add w3 space basic spec

### DIFF
--- a/w3-space.md
+++ b/w3-space.md
@@ -16,7 +16,6 @@ A Space can be defined as a namespace for stored content. It is created locally,
 
 - [Capabilities](#capabilities)
   - [`space/info`](#spaceinfo)
-  - [`space/allocate`](#spaceallocate)
 
 ## Language
 
@@ -70,54 +69,6 @@ Get information about a given space, such as registered providers.
         "did:web:free.web3.storage"
       ]
     }
-  }
-}
-```
-
-### `space/allocate`
-
-Allocate space to write content into the space
-
-> `did:key:zAliceAgent` invokes `space/allocate` capability provided by `did:web:web3.storage`
-
-```json
-{
-  "iss": "did:key:zAliceAgent",
-  "aud": "did:web:web3.storage",
-  "att": [
-    {
-      "with": "did:key:zAlice",
-      "can": "space/allocate",
-      "nb": {
-        "size": 1000
-      }
-    }
-  ],
-  "prf": [],
-  "sig": "..."
-}
-```
-
-#### Space Allocate Failure
-
-```json
-{
-  "ran": "bafy...spaceAllocate",
-  "out": {
-    "error": {
-      "name": "InsufficientStorage"
-    }
-  }
-}
-```
-
-#### Space Allocate Success
-
-```json
-{
-  "ran": "bafy...spaceAllocate",
-  "out": {
-    "ok": {}
   }
 }
 ```

--- a/w3-space.md
+++ b/w3-space.md
@@ -1,0 +1,126 @@
+# Space
+
+![status:reliable](https://img.shields.io/badge/status-reliable-green.svg?style=flat-square)
+
+## Editors
+
+- [Vasco Santos], [Protocol Labs]
+
+## Authors
+
+- [Vasco Santos], [Protocol Labs]
+
+## Abstract
+
+A Space can be defined as a namespace for stored content. It is created locally, offline, and associated with a cryptographic key pair (identified by the did:key of the public key). Afterwards, a space MAY be registered with a web3.storage [account](./w3-account.md) and [providers](./w3-provider.md) MAY be added to the space.
+
+- [Capabilities](#capabilities)
+  - [`space/info`](#spaceinfo)
+  - [`space/allocate`](#spaceallocate)
+
+## Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+## Capabilities
+
+### `space/info`
+
+Get information about a given space, such as registered providers.
+
+> `did:key:zAliceAgent` invokes `space/info` capability provided by `did:web:web3.storage`
+
+```json
+{
+  "iss": "did:key:zAliceAgent",
+  "aud": "did:web:web3.storage",
+  "att": [
+    {
+      "with": "did:key:zAlice",
+      "can": "space/info"
+    }
+  ],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+#### Space Info Failure
+
+```json
+{
+  "ran": "bafy...spaceInfo",
+  "out": {
+    "error": {
+      "name": "SpaceUnknown"
+    }
+  }
+}
+```
+
+#### Space Info Success
+
+```json
+{
+  "ran": "bafy...spaceInfo",
+  "out": {
+    "ok": {
+      "did": "did:key:zAlice",
+      "providers": [
+        "did:web:free.web3.storage"
+      ]
+    }
+  }
+}
+```
+
+### `space/allocate`
+
+Allocate space to write content into the space
+
+> `did:key:zAliceAgent` invokes `space/allocate` capability provided by `did:web:web3.storage`
+
+```json
+{
+  "iss": "did:key:zAliceAgent",
+  "aud": "did:web:web3.storage",
+  "att": [
+    {
+      "with": "did:key:zAlice",
+      "can": "space/allocate",
+      "nb": {
+        "size": 1000
+      }
+    }
+  ],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+#### Space Allocate Failure
+
+```json
+{
+  "ran": "bafy...spaceAllocate",
+  "out": {
+    "error": {
+      "name": "InsufficientStorage"
+    }
+  }
+}
+```
+
+#### Space Allocate Success
+
+```json
+{
+  "ran": "bafy...spaceAllocate",
+  "out": {
+    "ok": {}
+  }
+}
+```
+
+[Protocol Labs]: https://protocol.ai/
+[Vasco Santos]: https://github.com/vasco-santos


### PR DESCRIPTION
Adds basic space spec. While at first considered to add it to `w3-account` or `w3-access`, I realized that account has a specific focus on high level account with multiple spaces, while access focus on "aggregating and managing delegated capabilities across agents". Therefore, ended up with new spec document to reflect the basics of a space protocol.

It is complemented by `w3-account` and `w3-provider` on how to integrate account and providers, while in its basic form adds wire protocol for the space specific capabilities that do not fall under the umbrella of `account` and `provider`. 
