### PR TITLE
add implementation links for w3-filecoin

### DIFF
--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -241,6 +241,10 @@ The issued receipt MUST have a `fx.fork` [effect] that links to the [`filecoin/s
 }
 ```
 
+##### Implementations
+
+* `@web3-storage/capabilities` `filecoin/offer` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L20)
+
 #### `filecoin/accept`
 
 This task is effectively a shortcut allowing an observer to find out the result of the [`filecoin/offer`] task chain without having to follow each step. The [Storefront] MUST issue a signed receipt with a [`DataAggregationProof`] result or an error.
@@ -297,6 +301,10 @@ This task is effectively a shortcut allowing an observer to find out the result 
   }
 }
 ```
+
+##### Implementations
+
+* `@web3-storage/capabilities` `filecoin/accept` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L82)
 
 #### `filecoin/submit`
 
@@ -364,6 +372,10 @@ If the added piece is invalid, the reason for the failure is also reported:
   "prf": []
 }
 ```
+
+##### Implementations
+
+* `@web3-storage/capabilities` `filecoin/submit` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L50)
 
 #### `filecoin/info`
 
@@ -455,6 +467,10 @@ An agent MAY invoke the `filecoin/info` capability to request known information 
 }
 ```
 
+##### Implementations
+
+* `@web3-storage/capabilities` `filecoin/info` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L114)
+
 ### _Aggregator_ Capabilities
 
 #### `piece/offer`
@@ -506,6 +522,10 @@ An [Aggregator] MUST issue a signed receipt to acknowledge the received request.
 
 See the [`piece/accept`] section for the subsequent task.
 
+##### Implementations
+
+* `@web3-storage/capabilities` `piece/offer` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L22)
+
 #### `piece/accept`
 
 An [Aggregator] MUST issue a receipt for the [`piece/accept`] task for the offered piece that was included in an aggregate. The receipt MUST contain an [`InclusionProof`] in the result and an `fx.join` [effect] linking to [`aggregate/offer`] task, or an error detailing the reason.
@@ -541,6 +561,10 @@ An [Aggregator] MUST issue a receipt for the [`piece/accept`] task for the offer
   "prf": []
 }
 ```
+
+##### Implementations
+
+* `@web3-storage/capabilities` `piece/accept` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L66)
 
 ### _Dealer_ Capabilities
 
@@ -611,7 +635,11 @@ The [Dealer] MUST issue a signed receipt to acknowledge the request. The issued 
 
 See the [`aggregate/accept`](#aggregateaccept) section for the subsequent task.
 
-### `aggregate/accept`
+##### Implementations
+
+* `@web3-storage/capabilities` `aggregate/offer` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L66)
+
+#### `aggregate/accept`
 
 The [Dealer] MUST issue a receipt for the [`aggregate/accept`] task once it arranges deals with Storage Providers and they are live on the Filecoin chain. The receipt MUST either succeed with the [`DataAggregationProof`] or fail (with an `error` describing the problem with the `aggregate`).
 
@@ -669,6 +697,10 @@ If a deal fails due to an invalid piece, the issued receipt MUST contain `fx.for
   "prf": []
 }
 ```
+
+##### Implementations
+
+* `@web3-storage/capabilities` `aggregate/accept` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L48)
 
 ### _Deal Tracker_ Capabilities
 
@@ -750,6 +782,10 @@ The invocation to the [Deal Tracker] MUST fail if the deal information for the a
   "prf": []
 }
 ```
+
+##### Implementations
+
+* `@web3-storage/capabilities` `deal/info` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/deal-tracker.js#L17)
 
 ## Schema
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -243,8 +243,8 @@ The issued receipt MUST have a `fx.fork` [effect] that links to the [`filecoin/s
 
 ##### Implementations
 
-* `@web3-storage/capabilities` [`filecoin/offer` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L20)
-* `@web3-storage/filecoin-api` [storefront `filecoin/offer` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L20)
+- `@web3-storage/capabilities` [`filecoin/offer` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L20)
+- `@web3-storage/filecoin-api` [storefront `filecoin/offer` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L20)
 
 #### `filecoin/accept`
 
@@ -305,8 +305,8 @@ This task is effectively a shortcut allowing an observer to find out the result 
 
 ##### Implementations
 
-* `@web3-storage/capabilities` [`filecoin/accept` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L82)
-* `@web3-storage/filecoin-api` [storefront `filecoin/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L123)
+- `@web3-storage/capabilities` [`filecoin/accept` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L82)
+- `@web3-storage/filecoin-api` [storefront `filecoin/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L123)
 
 #### `filecoin/submit`
 
@@ -377,8 +377,8 @@ If the added piece is invalid, the reason for the failure is also reported:
 
 ##### Implementations
 
-* `@web3-storage/capabilities` [`filecoin/submit` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L50)
-* `@web3-storage/filecoin-api` [storefront `filecoin/submit` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L82)
+- `@web3-storage/capabilities` [`filecoin/submit` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L50)
+- `@web3-storage/filecoin-api` [storefront `filecoin/submit` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L82)
 
 #### `filecoin/info`
 
@@ -472,8 +472,8 @@ An agent MAY invoke the `filecoin/info` capability to request known information 
 
 ##### Implementations
 
-* `@web3-storage/capabilities` [`filecoin/info` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L114)
-* `@web3-storage/filecoin-api` [storefront `filecoin/info` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L239)
+- `@web3-storage/capabilities` [`filecoin/info` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L114)
+- `@web3-storage/filecoin-api` [storefront `filecoin/info` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L239)
 
 ### _Aggregator_ Capabilities
 
@@ -528,8 +528,8 @@ See the [`piece/accept`] section for the subsequent task.
 
 ##### Implementations
 
-* `@web3-storage/capabilities` [`piece/offer` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L22)
-* `@web3-storage/filecoin-api` [aggregator `piece/offer` method](https://github.com/web3-storage/w3up/blob/main/packages/filecoin-api/src/aggregator/service.js#L19)
+- `@web3-storage/capabilities` [`piece/offer` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L22)
+- `@web3-storage/filecoin-api` [aggregator `piece/offer` method](https://github.com/web3-storage/w3up/blob/main/packages/filecoin-api/src/aggregator/service.js#L19)
 
 #### `piece/accept`
 
@@ -569,8 +569,8 @@ An [Aggregator] MUST issue a receipt for the [`piece/accept`] task for the offer
 
 ##### Implementations
 
-* `@web3-storage/capabilities` [`piece/accept` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L66)
-* `@web3-storage/filecoin-api` [aggregator `piece/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/aggregator/service.js#L62)
+- `@web3-storage/capabilities` [`piece/accept` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L66)
+- `@web3-storage/filecoin-api` [aggregator `piece/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/aggregator/service.js#L62)
 
 ### _Dealer_ Capabilities
 
@@ -643,9 +643,9 @@ See the [`aggregate/accept`](#aggregateaccept) section for the subsequent task.
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `aggregate/offer` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L20)
-* `@web3-storage/filecoin-api` [`piece/accept` method creates `aggregate/offer` delegation](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/aggregator/service.js#L91)
-* `@web3-storage/filecoin-api` [dealer service `aggregate/offer` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L14)
+- `@web3-storage/capabilities` `aggregate/offer` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L20)
+- `@web3-storage/filecoin-api` [`piece/accept` method creates `aggregate/offer` delegation](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/aggregator/service.js#L91)
+- `@web3-storage/filecoin-api` [dealer service `aggregate/offer` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L14)
 
 #### `aggregate/accept`
 
@@ -708,9 +708,9 @@ If a deal fails due to an invalid piece, the issued receipt MUST contain `fx.for
 
 ##### Implementations
 
-* `@web3-storage/capabilities` [`aggregate/accept` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L48)
-* `@web3-storage/filecoin-api` [dealer `aggregate/offer` method ➡ `aggregate/accept` effect](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L69)
-* `@web3-storage/filecoin-api` [dealer `aggregate/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L92)
+- `@web3-storage/capabilities` [`aggregate/accept` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L48)
+- `@web3-storage/filecoin-api` [dealer `aggregate/offer` method ➡ `aggregate/accept` effect](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L69)
+- `@web3-storage/filecoin-api` [dealer `aggregate/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L92)
 
 ### _Deal Tracker_ Capabilities
 
@@ -795,8 +795,8 @@ The invocation to the [Deal Tracker] MUST fail if the deal information for the a
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `deal/info` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/deal-tracker.js#L17)
-* `@web3-storage/filecoin-api` [deal-tracker service `deal/info` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/deal-tracker/service.js#L15)
+- `@web3-storage/capabilities` `deal/info` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/deal-tracker.js#L17)
+- `@web3-storage/filecoin-api` [deal-tracker service `deal/info` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/deal-tracker/service.js#L15)
 
 ## Schema
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -709,7 +709,8 @@ If a deal fails due to an invalid piece, the issued receipt MUST contain `fx.for
 ##### Implementations
 
 * `@web3-storage/capabilities` [`aggregate/accept` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L48)
-* `@web3-storage/filecoin-api` [`aggregate/offer` method ➡ `aggregate/accept` effect](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L69)
+* `@web3-storage/filecoin-api` [dealer `aggregate/offer` method ➡ `aggregate/accept` effect](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L69)
+* `@web3-storage/filecoin-api` [dealer `aggregate/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L92)
 
 ### _Deal Tracker_ Capabilities
 

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -243,7 +243,8 @@ The issued receipt MUST have a `fx.fork` [effect] that links to the [`filecoin/s
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `filecoin/offer` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L20)
+* `@web3-storage/capabilities` [`filecoin/offer` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L20)
+* `@web3-storage/filecoin-api` [storefront `filecoin/offer` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L20)
 
 #### `filecoin/accept`
 
@@ -304,7 +305,8 @@ This task is effectively a shortcut allowing an observer to find out the result 
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `filecoin/accept` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L82)
+* `@web3-storage/capabilities` [`filecoin/accept` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L82)
+* `@web3-storage/filecoin-api` [storefront `filecoin/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L123)
 
 #### `filecoin/submit`
 
@@ -375,7 +377,8 @@ If the added piece is invalid, the reason for the failure is also reported:
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `filecoin/submit` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L50)
+* `@web3-storage/capabilities` [`filecoin/submit` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L50)
+* `@web3-storage/filecoin-api` [storefront `filecoin/submit` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L82)
 
 #### `filecoin/info`
 
@@ -469,7 +472,8 @@ An agent MAY invoke the `filecoin/info` capability to request known information 
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `filecoin/info` [capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L114)
+* `@web3-storage/capabilities` [`filecoin/info` capability validator](https://github.com/web3-storage/w3up/blob/adb24424d1faf50daf2339b77c22fdd44faa236a/packages/capabilities/src/filecoin/storefront.js#L114)
+* `@web3-storage/filecoin-api` [storefront `filecoin/info` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/storefront/service.js#L239)
 
 ### _Aggregator_ Capabilities
 
@@ -524,7 +528,8 @@ See the [`piece/accept`] section for the subsequent task.
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `piece/offer` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L22)
+* `@web3-storage/capabilities` [`piece/offer` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L22)
+* `@web3-storage/filecoin-api` [aggregator `piece/offer` method](https://github.com/web3-storage/w3up/blob/main/packages/filecoin-api/src/aggregator/service.js#L19)
 
 #### `piece/accept`
 
@@ -564,7 +569,8 @@ An [Aggregator] MUST issue a receipt for the [`piece/accept`] task for the offer
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `piece/accept` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L66)
+* `@web3-storage/capabilities` [`piece/accept` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L66)
+* `@web3-storage/filecoin-api` [aggregator `piece/accept` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/aggregator/service.js#L62)
 
 ### _Dealer_ Capabilities
 
@@ -637,7 +643,9 @@ See the [`aggregate/accept`](#aggregateaccept) section for the subsequent task.
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `aggregate/offer` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-client/src/aggregator.js#L66)
+* `@web3-storage/capabilities` `aggregate/offer` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L20)
+* `@web3-storage/filecoin-api` [`piece/accept` method creates `aggregate/offer` delegation](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/aggregator/service.js#L91)
+* `@web3-storage/filecoin-api` [dealer service `aggregate/offer` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L14)
 
 #### `aggregate/accept`
 
@@ -700,7 +708,8 @@ If a deal fails due to an invalid piece, the issued receipt MUST contain `fx.for
 
 ##### Implementations
 
-* `@web3-storage/capabilities` `aggregate/accept` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L48)
+* `@web3-storage/capabilities` [`aggregate/accept` capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/dealer.js#L48)
+* `@web3-storage/filecoin-api` [`aggregate/offer` method ➡ `aggregate/accept` effect](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/dealer/service.js#L69)
 
 ### _Deal Tracker_ Capabilities
 
@@ -786,6 +795,7 @@ The invocation to the [Deal Tracker] MUST fail if the deal information for the a
 ##### Implementations
 
 * `@web3-storage/capabilities` `deal/info` [capability validator](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/capabilities/src/filecoin/deal-tracker.js#L17)
+* `@web3-storage/filecoin-api` [deal-tracker service `deal/info` method](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/filecoin-api/src/deal-tracker/service.js#L15)
 
 ## Schema
 
@@ -819,7 +829,6 @@ type DealCapability union {
 } representation inline {
   discriminantKey "can"
 }
-
 
 type PieceRef struct {
   piece PieceLink


### PR DESCRIPTION
Rationale
* helps to understand protocol vs reality to see an impl
* i'm trying to ensure there are impl links for all [stable specs](https://github.com/web3-storage/specs#stable-specs), and this is one of them atm
