### PR TITLE
fix: add missing allocated field on store/add response

### DIFF
--- a/w3-store.md
+++ b/w3-store.md
@@ -136,12 +136,13 @@ On success, the response will include a `status` field, which may have one of th
 
 If `status == 'upload'`, the response will include additional fields containing information about the request, including the URL and headers needed to upload:
 
-| `field`   | `type`                   | `description`                                                   |
-| --------- | ------------------------ | --------------------------------------------------------------- |
-| `url`     | `string`                 | A URL that will accept a `PUT` request containing the CAR data. |
-| `headers` | `Record<string, string>` | HTTP headers that must be attached to the `PUT` request.        |
-| `with`    | `string`                 | The space resource URI used in the invocation.                  |
-| `link`    | `string`                 | The CAR CID specified in the invocation's `link` field.         |
+| `field`     | `type`                   | `description`                                                                                                                |
+| ----------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `url`       | `string`                 | A URL that will accept a `PUT` request containing the CAR data.                                                              |
+| `headers`   | `Record<string, string>` | HTTP headers that must be attached to the `PUT` request.                                                                     |
+| `with`      | `string`                 | The space resource URI used in the invocation.                                                                               |
+| `link`      | `string`                 | The CAR CID specified in the invocation's `link` field.                                                                      |
+| `allocated` | `number`                 | Total bytes allocated in the space to accommodate the stored item. May be zero if the item is _already_ stored in the space. |
 
 The client should then make an HTTP `PUT` request to the `url` specified in the response, attaching all the included `headers`. The body of the request MUST be CAR data, whose size exactly equals the size specified in the `store/add` invocation's `size` caveat. Additionally, the CID of the uploaded CAR must match the invocation's `link` caveat. In other words, attempting to upload any data other than that authorized by the `store/add` invocation will fail.
 

--- a/w3-store.md
+++ b/w3-store.md
@@ -136,13 +136,14 @@ On success, the response will include a `status` field, which may have one of th
 
 If `status == 'upload'`, the response will include additional fields containing information about the request, including the URL and headers needed to upload:
 
-| `field`     | `type`                   | `description`                                                                                                                |
-| ----------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `url`       | `string`                 | A URL that will accept a `PUT` request containing the CAR data.                                                              |
-| `headers`   | `Record<string, string>` | HTTP headers that must be attached to the `PUT` request.                                                                     |
-| `with`      | `string`                 | The space resource URI used in the invocation.                                                                               |
-| `link`      | `string`                 | The CAR CID specified in the invocation's `link` field.                                                                      |
-| `allocated` | `number`                 | Total bytes allocated in the space to accommodate the stored item. May be zero if the item is _already_ stored in the space. |
+
+| `field`   | `type`                   | `description`                                                   |
+| --------- | ------------------------ | --------------------------------------------------------------- |
+| `url`     | `string`                 | A URL that will accept a `PUT` request containing the CAR data. |
+| `headers` | `Record<string, string>` | HTTP headers that must be attached to the `PUT` request.        |
+| `with`    | `string`                 | The space resource URI used in the invocation.                  |
+| `link`    | `string`                 | The CAR CID specified in the invocation's `link` field.         |
+| `allocated` | `number`               | Total bytes allocated in the space to accommodate the stored item. May be zero if the item is _already_ stored in the space. |
 
 The client should then make an HTTP `PUT` request to the `url` specified in the response, attaching all the included `headers`. The body of the request MUST be CAR data, whose size exactly equals the size specified in the `store/add` invocation's `size` caveat. Additionally, the CID of the uploaded CAR must match the invocation's `link` caveat. In other words, attempting to upload any data other than that authorized by the `store/add` invocation will fail.
 


### PR DESCRIPTION
Documents the `allocated` field that appears on the `store/add` response.