### PR TITLE
spec: Content Serve Authorization

### DIFF
--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -18,7 +18,7 @@ This mechanism allows content owners to delegate retrieval capabilities to speci
 
 ## Terminology
 
-- **Space**: A logical container for data, identified by a DID (Decentralized Identifier). Authorization is granted for an entire space, and all data within a space shares the same permissions.
+- **Space**: A logical container for data, identified by a DID (Decentralized Identifier).
 - **Delegation**: The act of granting specific capabilities to another entity via UCAN, and the signed document proving the delegation (also called a "**proof**").
 - **IPFS Gateway**: A service that implements the [IPFS HTTP Gateway spec](https://specs.ipfs.tech/http-gateways/) to facilitate content retrieval, that _also_ enforces authorization policies.
 - **Delegations Store**: A store used by a Gateway to store and manage delegations.
@@ -45,65 +45,69 @@ sequenceDiagram
 1. Client creates a UCAN delegation granting `space/content/serve` capability to the gateway
 
    - The `space/content/serve` capability is delegated to the service(s) designed to serve content stored by the Storacha Network (for example an IPFS Gateway).
-   - A `space/content/serve` delegation authorizes the service to serve data stored in a given space. Caveats MAY apply.
+   - A `space/content/serve` delegation authorizes the service to serve data stored in a given space. Caveats MAY apply. The authorization is granted for the entire space, and all data within a space shares the same permissions.
    - In the future, IPFS Gateways may support different delegation strategies such as: restricting access to specific CIDs, use of access tokens, restrictions on transport modes (http/bitswap).
 
 2. Client wraps this delegation in an `access/delegate` UCAN invocation
-3. Client encodes the invocation as CAR format and sends to `POST /`
-4. Gateway validates the delegation chain and stores the delegation
+3. Client encodes the invocation and sends it to the IPFS Gateway
+4. The IPFS Gateway validates the delegation chain and stores the delegation
 
    - Multiple delegations can exist for the same space, allowing flexibility in access control.
 
-Note: This is a standard Ucanto invocation flow.
+Note: The `access/delegate` is a standard Ucanto invocation flow, and additionally, the `space/content/serve` delegation needs to be validated because it is not automatically part of the invocation flow.
 
 ## API Specification
 
 The IPFS Gateway needs to provide an endpoint with the following interface to process the delegation requests.
 
-```http
-POST /
-Content-Type: application/car
+### `space/content/serve` Delegation Structure
+
+```jsonc
+{ // "/": "bafy...serveprf1",
+  // The Agent sending the request that authorizes the IPFS Gateway
+  "iss": "did:key:zAlice",
+  // The IPFS Gateway DID that is authorized to serve the content
+  "aud": "did:web:storacha.link",
+  "att": [
+    {
+      // The capability
+      "can": "space/content/serve",
+      // The Space DID Key
+      "with": "did:key:zSpace",
+    }
+  ],
+  "prf": [],
+}
 ```
-
-### Request Body
-
-- CAR-encoded UCAN invocation
 
 ### `access/delegate` Invocation Structure
 
-```typescript
-interface UCANInvocation {
-  /** The Agent sending the request */
-  iss: string; // e.g., "did:key:…"
-  /** The IPFS Gateway DID that will receive the delegation */
-  aud: string; // e.g., "did:web:storacha.link"
-  /**
-   * The space DID key where the content is stored and is allowed to be served from.
-   */
-  with: string; // e.g., "did:key:…"
-  nb: {
-    /** Map of delegation CIDs to be stored */
-    delegations: Record<string, CID>
-  }
-  /** Array of UCAN delegations proving space/content/serve capability */
-  proofs: Delegation[]
+```jsonc
+{ // "/": "bafy...delegate",
+  // The Agent sending the request
+  "iss": "did:key:zAlice",
+  // The IPFS Gateway DID that will receive the delegation
+  "aud": "did:web:storacha.link",
+  // The space DID key where the content is stored and is allowed to be served from
+  "with": "did:key:zAliceSpace",
+  "att": [
+    {
+      "with": "did:key:zAlice",
+      "can": "access/delegate",
+      "nb": {
+        // Map of delegation CIDs to be stored
+        "delegations": { "bafy...serveprf1": { "/": "bafy...serveprf1" } }
+      }
+    }
+  ],
+  // Array of UCAN delegations including the space/content/serve proof
+  "prf": [
+    // `space/content/serve` delegation proof (e.g: {"/": "bafy...serveprf1"})
+  ]
 }
 ```
 
-### `space/content/serve` Delegation Structure
 
-(contained in proofs):
-
-```typescript
-interface ContentServeDelegation {
-  /** The capability being delegated */
-  can: "space/content/serve"
-  /** Space DID being delegated */
-  with: string  // e.g., "did:key:z6Mk..."
-  /** Optional restrictions (currently unused) */
-  nb: {}
-}
-```
 
 ### Response Codes
 

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -13,17 +13,18 @@
 
 ## Abstract
 
-Content Server Authorization ensures that access to content is governed by UCAN delegations (User Controlled Authorization Network) and served by explicitly authorized services.
+Content Server Authorization ensures that access to content is governed by UCAN (User Controlled Authorization Network) delegations and served by explicitly authorized services.
 This mechanism allows content owners to delegate retrieval capabilities to specific services, ensuring that only authorized entities can access the content.
 
 ## Terminology
 
 - **Space**: A logical container for data, identified by a DID (Decentralized Identifier).
 - **Delegation**: The act of granting specific capabilities to another entity via UCAN, and the signed document proving the delegation (also called a "**proof**").
-- **IPFS Gateway**: A service that implements the [IPFS HTTP Gateway spec](https://specs.ipfs.tech/http-gateways/) to facilitate content retrieval, that _also_ enforces authorization policies.
+- **IPFS Gateway**: A service that implements the [IPFS HTTP Gateway spec](https://specs.ipfs.tech/http-gateways/) to facilitate content retrieval.
+- **UCAN Authorized IPFS Gateway**: An IPFS gateway that _also_ enforces authorization policies. Referred to as simply "Gateway" herein.
 - **Delegations Store**: A store used by a Gateway to store and manage delegations.
 
-## Delegation Flow Diagram for an IPFS Gateway
+## Delegation Flow Diagram for a Gateway
 
 ```mermaid
 sequenceDiagram
@@ -42,14 +43,14 @@ sequenceDiagram
 
 ### Flow
 
-1. Client creates a UCAN delegation granting `space/content/serve` capability to the gateway
+1. Client creates a UCAN delegation granting `space/content/serve` capability to the Gateway
 
-   - The `space/content/serve` capability is delegated to the service(s) designed to serve content stored by the Storacha Network (for example an IPFS Gateway).
+   - The `space/content/serve` capability is delegated to the service(s) designed to serve content stored by the Storacha Network (in this case an IPFS Gateway).
    - A `space/content/serve` delegation authorizes the service to serve data stored in a given space. Caveats MAY apply. The authorization is granted for the entire space, and all data within a space shares the same permissions.
-   - In the future, IPFS Gateways may support different delegation strategies such as: restricting access to specific CIDs, use of access tokens, restrictions on transport modes (http/bitswap).
+   - In the future, Gateways may support different delegation strategies such as: restricting access to specific CIDs, use of access tokens, restrictions on transport modes (http/bitswap).
 
-2. Client wraps this delegation in an `access/delegate` UCAN invocation
-3. Client encodes the invocation and sends it to the IPFS Gateway
+2. Client wraps this delegation in an [`access/delegate` UCAN invocation](https://github.com/storacha/specs/blob/main/w3-access.md#access-delegate)
+3. Client encodes the invocation and sends it to the Gateway
 4. The IPFS Gateway validates the delegation chain and stores the delegation
 
    - Multiple delegations can exist for the same space, allowing flexibility in access control.

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -107,8 +107,6 @@ The IPFS Gateway needs to provide an endpoint with the following interface to pr
 }
 ```
 
-
-
 ### Response Codes
 
 - `200 OK`: Delegation accepted and stored

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -10,14 +10,13 @@
 
 ## Abstract
 
-Content Server Authorization ensures that access to content is governed by delegations using UCANs (User Controlled Authorization Networks) and served by explicitly authorized services.
+Content Server Authorization ensures that access to content is governed by UCAN delegations (User Controlled Authorization Network) and served by explicitly authorized services.
 This mechanism allows content owners to delegate retrieval capabilities to specific services, ensuring that only authorized entities can access the content.
 
 ## Terminology
 
-- **UCAN**: User Controlled Authorization Network token/delegation, representing delegated capabilities.
-- **Space**: A logical namespace identified by a DID (Decentralized Identifier) utilized to store data (e.g: bucket).
-- **Delegation**: The act of granting specific capabilities to another entity via a UCAN.
+- **Space**: A logical container for data, identified by a DID (Decentralized Identifier). Authorization is granted for an entire space, and all data within a space shares the same permissions.
+- **Delegation**: The act of granting specific capabilities to another entity via UCAN, and the signed document proving the delegation (also called a "**proof**").
 - **Gateway**: A service (e.g., Freeway) that facilitates content retrieval and enforces authorization policies.
 - **Delegations KV Store**: A key-value store used by the gateway to manage and validate delegations.
 
@@ -28,7 +27,7 @@ The delegation process involves the following steps
 1. **Space Creation and Delegation**
 
    - A user creates a space using the Storacha client.
-   - The Storacha Client automatically delegates the `space/content/serve` capability to the Storacha Gateway (e.g., Freeway) by sending a `POST /access/delegate` request containing the UCAN delegation.
+   - During space creation, the Storacha Client delegates the `space/content/serve` capability to the Storacha Gateway (e.g., Freeway) by sending a `POST /access/delegate` request containing the UCAN delegation.
    - The Gateway validates the UCAN delegation and stores it in the Delegations KV store.
 
 2. **Delegation Storage**

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -20,8 +20,8 @@ This mechanism allows content owners to delegate retrieval capabilities to speci
 
 - **Space**: A logical container for data, identified by a DID (Decentralized Identifier). Authorization is granted for an entire space, and all data within a space shares the same permissions.
 - **Delegation**: The act of granting specific capabilities to another entity via UCAN, and the signed document proving the delegation (also called a "**proof**").
-- **Gateway**: A service (e.g., Freeway) that facilitates content retrieval and enforces authorization policies.
-- **Delegations Store**: A store used by the IPFS gateway to store and manage delegations.
+- **IPFS Gateway**: A service that implements the [IPFS HTTP Gateway spec](https://specs.ipfs.tech/http-gateways/) to facilitate content retrieval, that _also_ enforces authorization policies.
+- **Delegations Store**: A store used by a Gateway to store and manage delegations.
 
 ## Delegation Flow Diagram for an IPFS Gateway
 
@@ -44,15 +44,14 @@ sequenceDiagram
 
 1. Client creates a UCAN delegation granting `space/content/serve` capability to the gateway
 
-   - During space creation, the Storacha Client delegates the `space/content/serve` capability to the services designed to serve content from the Storacha Network to clients (for example an IPFS Gateway), by sending a `POST /access/delegate` request containing the UCAN delegation.
-   - `space/content/serve`: delegation that authorizes the service to serve data stored in a given space to any client requesting it.
+   - The `space/content/serve` capability is delegated to the service(s) designed to serve content stored by the Storacha Network (for example an IPFS Gateway).
+   - A `space/content/serve` delegation authorizes the service to serve data stored in a given space. Caveats MAY apply.
    - In the future, IPFS Gateways may support different delegation strategies such as: restricting access to specific CIDs, use of access tokens, restrictions on transport modes (http/bitswap).
 
 2. Client wraps this delegation in an `access/delegate` UCAN invocation
 3. Client encodes the invocation as CAR format and sends to `POST /`
 4. Gateway validates the delegation chain and stores the delegation
 
-   - For the Storacha IPFS Gateway, the Delegations are stored using a key composed of the space DID and the delegation CID, but the implementer can use any strategy to store the delegations.
    - Multiple delegations can exist for the same space, allowing flexibility in access control.
 
 Note: This is a standard Ucanto invocation flow.

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -1,0 +1,112 @@
+# Content Server Authorization Spec
+
+## Editors
+
+- [Felipe Forbeck](https://github.com/fforbeck), [Storacha Network](https://storacha.network/)
+
+## Authors
+
+- [Felipe Forbeck](https://github.com/fforbeck), [Storacha Network](https://storacha.network/)
+
+
+## Abstract
+
+Content Server Authorization ensures that access to content is governed by delegations using UCANs (User Controlled Authorization Networks) and served by explicitly authorized services.
+This mechanism allows content owners to delegate retrieval capabilities to specific services, ensuring that only authorized entities can access the content.
+
+## Terminology
+
+* **UCAN**: User Controlled Authorization Network token/delegation, representing delegated capabilities.
+* **Space**: A logical namespace identified by a DID (Decentralized Identifier) utilized to store data (e.g: bucket).
+* **Delegation**: The act of granting specific capabilities to another entity via a UCAN.
+* **Gateway**: A service (e.g., Freeway) that facilitates content retrieval and enforces authorization policies.
+* **Delegations KV Store**: A key-value store used by the gateway to manage and validate delegations.
+
+## Delegation Flow
+
+The delegation process involves the following steps
+
+1. **Space Creation and Delegation**
+
+   * A user creates a space using the Storacha client.
+   * The Storacha Client automatically delegates the `space/content/serve` capability to the Storacha Gateway (e.g., Freeway) by sending a `POST /access/delegate` request containing the UCAN delegation.
+   * The Gateway validates the UCAN delegation and stores it in the Delegations KV store.
+
+2. **Delegation Storage**
+
+   * Delegations are stored using a key composed of the space DID and the delegation CID.
+   * Multiple delegations can exist for the same space/bucket, allowing flexibility in access control.
+
+### Delegation Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Client
+    participant Gateway
+    participant DelegationsKV
+
+    User->>Client: Create Space (DID)
+    Client->>Gateway: POST /access/delegate (UCAN)
+    Gateway->>DelegationsKV: Store Delegation (space DID + delegation CID)
+    Gateway-->>Client: Delegation Acknowledged
+```
+
+
+
+## Content Retrieval Flow
+
+When a client requests content
+
+1. **Request Handling**
+
+   * The client sends a `GET /ipfs/:cid` request to the Gateway.
+   * The Gateway resolves the associated space/bucket and retrieves the relevant delegations from the KV store.
+
+2. **Authorization Check**
+
+   * The Gateway validates the UCAN delegations to ensure the requester has the `space/content/serve` capability for the content's space.
+   * If authorized, the content is served; otherwise, the request is denied.
+
+### Content Retrieval Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant DelegationsKV
+    participant ContentStore
+
+    Client->>Gateway: GET /ipfs/:cid
+    Gateway->>DelegationsKV: Retrieve Delegations (space DID)
+    Gateway->>Gateway: Validate UCAN Proofs
+    alt Authorized
+        Gateway->>ContentStore: Fetch Content
+        Gateway-->>Client: Serve Content
+    else Not Authorized
+        Gateway-->>Client: 403 Forbidden
+    end
+```
+
+
+
+## Considerations
+
+* **Legacy Spaces**
+
+  * For spaces created before the implementation of Content Serve Authorization, the Gateway serves content without requiring authorization, provided no authorization header is present.
+
+* **Access Tokens**
+
+  * :warning: The system supports the use of access tokens in request headers, although current implementations do not enforce token validation at the delegation level.
+
+* **Billing**
+
+  * Determining the space ID is essential for attributing egress costs to the correct account. This billing mechanism is under development and depends on the unification of the `upload-service` and `w3up` repositories.
+
+## References
+
+* [Content Authorization Flow - HackMD](https://hackmd.io/E22bpXWcS6e9JQpe0lvy5w?view#13-Document-Access-Control-amp-Revocation)
+* [Issue #159 - Project Tracking](https://github.com/storacha/project-tracking/issues/159#issuecomment-2483570784)
+* [Issue #137 - Project Tracking](https://github.com/storacha/project-tracking/issues/137#issuecomment-2459892514)
+* [Issue #158 - Project Tracking](https://github.com/storacha/project-tracking/issues/158#issuecomment-2504194988)

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -74,11 +74,14 @@ Content-Type: application/car
 
 ```typescript
 interface UCANInvocation {
-  /** The capability being invoked */
-  can: "access/delegate"
+  /** The Agent sending the request */
+  iss: string; // e.g., "did:key:…"
   /** The IPFS Gateway DID that will receive the delegation */
-  with: string  // e.g., "did:web:storacha.link"
-  /** Invocation parameters */
+  aud: string; // e.g., "did:web:storacha.link"
+  /**
+   * The space DID key where the content is stored and is allowed to be served from.
+   */
+  with: string; // e.g., "did:key:…"
   nb: {
     /** Map of delegation CIDs to be stored */
     delegations: Record<string, CID>

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -16,11 +16,11 @@ This mechanism allows content owners to delegate retrieval capabilities to speci
 
 ## Terminology
 
-* **UCAN**: User Controlled Authorization Network token/delegation, representing delegated capabilities.
-* **Space**: A logical namespace identified by a DID (Decentralized Identifier) utilized to store data (e.g: bucket).
-* **Delegation**: The act of granting specific capabilities to another entity via a UCAN.
-* **Gateway**: A service (e.g., Freeway) that facilitates content retrieval and enforces authorization policies.
-* **Delegations KV Store**: A key-value store used by the gateway to manage and validate delegations.
+- **UCAN**: User Controlled Authorization Network token/delegation, representing delegated capabilities.
+- **Space**: A logical namespace identified by a DID (Decentralized Identifier) utilized to store data (e.g: bucket).
+- **Delegation**: The act of granting specific capabilities to another entity via a UCAN.
+- **Gateway**: A service (e.g., Freeway) that facilitates content retrieval and enforces authorization policies.
+- **Delegations KV Store**: A key-value store used by the gateway to manage and validate delegations.
 
 ## Delegation Flow
 
@@ -28,14 +28,14 @@ The delegation process involves the following steps
 
 1. **Space Creation and Delegation**
 
-   * A user creates a space using the Storacha client.
-   * The Storacha Client automatically delegates the `space/content/serve` capability to the Storacha Gateway (e.g., Freeway) by sending a `POST /access/delegate` request containing the UCAN delegation.
-   * The Gateway validates the UCAN delegation and stores it in the Delegations KV store.
+   - A user creates a space using the Storacha client.
+   - The Storacha Client automatically delegates the `space/content/serve` capability to the Storacha Gateway (e.g., Freeway) by sending a `POST /access/delegate` request containing the UCAN delegation.
+   - The Gateway validates the UCAN delegation and stores it in the Delegations KV store.
 
 2. **Delegation Storage**
 
-   * Delegations are stored using a key composed of the space DID and the delegation CID.
-   * Multiple delegations can exist for the same space/bucket, allowing flexibility in access control.
+   - Delegations are stored using a key composed of the space DID and the delegation CID.
+   - Multiple delegations can exist for the same space/bucket, allowing flexibility in access control.
 
 ### Delegation Flow Diagram
 
@@ -60,13 +60,13 @@ When a client requests content
 
 1. **Request Handling**
 
-   * The client sends a `GET /ipfs/:cid` request to the Gateway.
-   * The Gateway resolves the associated space/bucket and retrieves the relevant delegations from the KV store.
+   - The client sends a `GET /ipfs/:cid` request to the Gateway.
+   - The Gateway resolves the associated space/bucket and retrieves the relevant delegations from the KV store.
 
 2. **Authorization Check**
 
-   * The Gateway validates the UCAN delegations to ensure the requester has the `space/content/serve` capability for the content's space.
-   * If authorized, the content is served; otherwise, the request is denied.
+   - The Gateway validates the UCAN delegations to ensure the requester has the `space/content/serve` capability for the content's space.
+   - If authorized, the content is served; otherwise, the request is denied.
 
 ### Content Retrieval Flow Diagram
 
@@ -92,21 +92,21 @@ sequenceDiagram
 
 ## Considerations
 
-* **Legacy Spaces**
+- **Legacy Spaces**
 
-  * For spaces created before the implementation of Content Serve Authorization, the Gateway serves content without requiring authorization, provided no authorization header is present.
+  - For spaces created before the implementation of Content Serve Authorization, the Gateway serves content without requiring authorization, provided no authorization header is present.
 
-* **Access Tokens**
+- **Access Tokens**
 
-  * :warning: The system supports the use of access tokens in request headers, although current implementations do not enforce token validation at the delegation level.
+  - :warning: The system supports the use of access tokens in request headers, although current implementations do not enforce token validation at the delegation level.
 
-* **Billing**
+- **Billing**
 
-  * Determining the space ID is essential for attributing egress costs to the correct account. This billing mechanism is under development and depends on the unification of the `upload-service` and `w3up` repositories.
+  - Determining the space ID is essential for attributing egress costs to the correct account. This billing mechanism is under development and depends on the unification of the `upload-service` and `w3up` repositories.
 
 ## References
 
-* [Content Authorization Flow - HackMD](https://hackmd.io/E22bpXWcS6e9JQpe0lvy5w?view#13-Document-Access-Control-amp-Revocation)
-* [Issue #159 - Project Tracking](https://github.com/storacha/project-tracking/issues/159#issuecomment-2483570784)
-* [Issue #137 - Project Tracking](https://github.com/storacha/project-tracking/issues/137#issuecomment-2459892514)
-* [Issue #158 - Project Tracking](https://github.com/storacha/project-tracking/issues/158#issuecomment-2504194988)
+- [Content Authorization Flow - HackMD](https://hackmd.io/E22bpXWcS6e9JQpe0lvy5w?view#13-Document-Access-Control-amp-Revocation)
+- [Issue #159 - Project Tracking](https://github.com/storacha/project-tracking/issues/159#issuecomment-2483570784)
+- [Issue #137 - Project Tracking](https://github.com/storacha/project-tracking/issues/137#issuecomment-2459892514)
+- [Issue #158 - Project Tracking](https://github.com/storacha/project-tracking/issues/158#issuecomment-2504194988)

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -48,7 +48,7 @@ sequenceDiagram
       - For the Storacha IPFS Gateway, the Delegations are stored using a key composed of the space DID and the delegation CID, but the implementer can use any strategy to store the delegations.
       - Multiple delegations can exist for the same space, allowing flexibility in access control.
 
-### API Specification
+## API Specification
 
 The IPFS Gateway needs to provide an endpoint with the following interface to process the delegation requests.
 
@@ -98,6 +98,26 @@ interface ContentServeDelegation {
 
 ## Content Retrieval Flow
 
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Delegations Store
+    participant ContentStore
+
+    Client->>Gateway: GET /ipfs/:cid (no UCAN signature)
+    Gateway->>Gateway: Resolve content to Space DID
+    Gateway->>Delegations Store: Retrieve space/content/serve delegations
+    Gateway->>Gateway: Create UCAN invocation (self-authorize)
+    Gateway->>Gateway: Validate invocation using stored proofs
+    alt Authorized
+        Gateway->>ContentStore: Fetch Content
+        Gateway-->>Client: Serve Content
+    else Not Authorized
+        Gateway-->>Client: 403 Forbidden
+    end
+```
+
 When a client requests content
 
 1. **Request Handling**
@@ -107,30 +127,20 @@ When a client requests content
 
 2. **Authorization Check**
 
-   - The Gateway validates the UCAN delegations to ensure the requester has the `space/content/serve` capability for the content's space.
-   - If authorized, the content is served; otherwise, the request is denied.
-
-### Content Retrieval Flow Diagram
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Gateway
-    participant Delegations Store
-    participant ContentStore
-
-    Client->>Gateway: GET /ipfs/:cid
-    Gateway->>Delegations Store: Retrieve Delegations (space DID)
-    Gateway->>Gateway: Validate UCAN Proofs
-    alt Authorized
-        Gateway->>ContentStore: Fetch Content
-        Gateway-->>Client: Serve Content
-    else Not Authorized
-        Gateway-->>Client: 403 Forbidden
-    end
-```
+   - The Gateway looks up stored delegations for the content's space from the Delegations Store.
+   - The Gateway creates a UCAN invocation authorizing itself to serve the content, using the stored `space/content/serve` delegations as proofs.
+   - The Gateway validates its own UCAN invocation against the stored delegation proofs.
+   - If the validation succeeds, the content is served; otherwise, the request is denied with 403 Forbidden.
+   
+   **Note**: The HTTP client making the GET request does not need a DID or UCAN signature. The authorization happens between the Gateway (as the delegated authority) and the Space owner (via pre-stored delegations).
 
 ## Considerations
+
+- **Gateway as Delegated Authority**
+
+  - The IPFS Gateway itself (with a DID like `did:web:storacha.link`) is the UCAN principal that has been delegated the `space/content/serve` capability.
+  - HTTP clients making content requests do not need DIDs or UCAN signatures - they are not UCAN principals in this system.
+  - Authorization happens between the Gateway and Space owners via pre-stored delegations, not between HTTP clients and the Gateway.
 
 - **Legacy Spaces**
 

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -84,6 +84,7 @@ interface UCANInvocation {
 ```
 
 ### Space Content Serve Delegation Structure
+
 (contained in proofs):
 
 ```typescript
@@ -139,8 +140,7 @@ When a client requests content
    - The Gateway creates a UCAN invocation authorizing itself to serve the content, using the stored `space/content/serve` delegations as proofs.
    - The Gateway validates its own UCAN invocation against the stored delegation proofs.
    - If the validation succeeds, the content is served; otherwise, the request is denied with 403 Forbidden.
-   
-   **Note**: The HTTP client making the GET request does not need a DID or UCAN signature. The authorization happens between the Gateway (as the delegated authority) and the Space owner (via pre-stored delegations).
+   - **Note**: The HTTP client making the GET request does not need a DID or UCAN signature. The authorization happens between the Gateway (as the delegated authority) and the Space owner (via stored delegations).
 
 ## Considerations
 
@@ -148,7 +148,7 @@ When a client requests content
 
   - The IPFS Gateway itself (with a DID like `did:web:storacha.link`) is the UCAN principal that has been delegated the `space/content/serve` capability.
   - HTTP clients making content requests do not need DIDs or UCAN signatures - they are not UCAN principals in this system.
-  - Authorization happens between the Gateway and Space owners via pre-stored delegations, not between HTTP clients and the Gateway.
+  - Authorization happens between the Gateway and Space owners via stored delegations, not between HTTP clients and the Gateway.
 
 - **Legacy Spaces**
 

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -18,37 +18,83 @@ This mechanism allows content owners to delegate retrieval capabilities to speci
 - **Space**: A logical container for data, identified by a DID (Decentralized Identifier). Authorization is granted for an entire space, and all data within a space shares the same permissions.
 - **Delegation**: The act of granting specific capabilities to another entity via UCAN, and the signed document proving the delegation (also called a "**proof**").
 - **Gateway**: A service (e.g., Freeway) that facilitates content retrieval and enforces authorization policies.
-- **Delegations KV Store**: A key-value store used by the gateway to manage and validate delegations.
+- **Delegations Store**: A store used by the IPFS gateway to store and manage delegations.
 
-## Delegation Flow
-
-The delegation process involves the following steps
-
-1. **Space Creation and Delegation**
-
-   - A user creates a space using the Storacha client.
-   - During space creation, the Storacha Client delegates the `space/content/serve` capability to the Storacha Gateway (e.g., Freeway) by sending a `POST /access/delegate` request containing the UCAN delegation.
-   - The Gateway validates the UCAN delegation and stores it in the Delegations KV store.
-
-2. **Delegation Storage**
-
-   - Delegations are stored using a key composed of the space DID and the delegation CID.
-   - Multiple delegations can exist for the same space/bucket, allowing flexibility in access control.
-
-### Delegation Flow Diagram
+## Delegation Flow Diagram for an IPFS Gateway
 
 ```mermaid
 sequenceDiagram
     participant User
     participant Client
     participant Gateway
-    participant DelegationsKV
+    participant Delegations Store
 
     User->>Client: Create Space (DID)
-    Client->>Gateway: POST /access/delegate (UCAN)
-    Gateway->>DelegationsKV: Store Delegation (space DID + delegation CID)
+    Client->>Gateway: POST / (CAR-encoded UCAN)
+    Gateway->>Gateway: Validate access/delegate UCAN Invocation
+    Gateway->>Gateway: Extract and validate space/content/serve delegation
+    Gateway->>Delegations Store: Store Delegation (Space DID + Delegation CID)
     Gateway-->>Client: Delegation Acknowledged
 ```
+
+**Flow**
+   1. Client creates a UCAN delegation granting `space/content/serve` capability to the gateway
+      - During space creation, the Storacha Client delegates the `space/content/serve` capability to the services designed to serve content from the Storacha Network to clients (for example an IPFS Gateway), by sending a `POST /access/delegate` request containing the UCAN delegation.
+      - `space/content/serve`: delegation that authorizes the service to serve data stored in a given space to any client requesting it.
+      - In the future, IPFS Gateways may support different delegation strategies such as: restricting access to specific CIDs, use of access tokens, restrictions on transport modes (http/bitswap).
+   2. Client wraps this delegation in an `access/delegate` UCAN invocation
+   3. Client encodes the invocation as CAR format and sends to `POST /`
+   4. Gateway validates the delegation chain and stores the delegation
+      - For the Storacha IPFS Gateway, the Delegations are stored using a key composed of the space DID and the delegation CID, but the implementer can use any strategy to store the delegations.
+      - Multiple delegations can exist for the same space, allowing flexibility in access control.
+
+### API Specification
+
+The IPFS Gateway needs to provide an endpoint with the following interface to process the delegation requests.
+
+```http
+POST /
+Content-Type: application/car
+```
+
+**Request Body**
+
+ - CAR-encoded UCAN invocation
+
+**UCAN Invocation Structure**
+```typescript
+interface UCANInvocation {
+  /** The capability being invoked */
+  can: "access/delegate"
+  /** The IPFS Gateway DID that will receive the delegation */
+  with: string  // e.g., "did:web:storacha.link"
+  /** Invocation parameters */
+  nb: {
+    /** Map of delegation CIDs to be stored */
+    delegations: Record<string, CID>
+  }
+  /** Array of UCAN delegations containing space/content/serve capability */
+  proofs: Delegation[]
+}
+```
+
+**Space Content Serve Delegation Structure** (contained in proofs):
+```typescript
+interface ContentServeDelegation {
+  /** The capability being delegated */
+  can: "space/content/serve"
+  /** Space DID being delegated */
+  with: string  // e.g., "did:key:z6Mk..."
+  /** Optional restrictions (currently unused) */
+  nb: {}
+}
+```
+
+**Response Codes**
+- `200 OK`: Delegation accepted and stored
+- `400 Bad Request`: Invalid UCAN or malformed request
+- `403 Forbidden`: Unauthorized to delegate for this space
+- `500 Internal Server Error`: Server-side validation or storage failure
 
 ## Content Retrieval Flow
 
@@ -57,7 +103,7 @@ When a client requests content
 1. **Request Handling**
 
    - The client sends a `GET /ipfs/:cid` request to the Gateway.
-   - The Gateway resolves the associated space/bucket and retrieves the relevant delegations from the KV store.
+   - The Gateway resolves the associated Space DID by looking up the CID in the Indexer Service, identifying the existing Spaces in the Location Claims response, and retrieving all delegations from the Delegations Store.
 
 2. **Authorization Check**
 
@@ -70,11 +116,11 @@ When a client requests content
 sequenceDiagram
     participant Client
     participant Gateway
-    participant DelegationsKV
+    participant Delegations Store
     participant ContentStore
 
     Client->>Gateway: GET /ipfs/:cid
-    Gateway->>DelegationsKV: Retrieve Delegations (space DID)
+    Gateway->>Delegations Store: Retrieve Delegations (space DID)
     Gateway->>Gateway: Validate UCAN Proofs
     alt Authorized
         Gateway->>ContentStore: Fetch Content
@@ -88,7 +134,7 @@ sequenceDiagram
 
 - **Legacy Spaces**
 
-  - For spaces created before the implementation of Content Serve Authorization, the Gateway serves content without requiring authorization, provided no authorization header is present.
+  - For Spaces created before the implementation of Content Serve Authorization, considered legacy data, the Gateway serves content without requiring authorization because it can't be attributed to a Space DID for billing.
 
 - **Access Tokens**
 

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -65,7 +65,7 @@ Content-Type: application/car
 
 - CAR-encoded UCAN invocation
 
-### UCAN Invocation Structure
+### `access/delegate` Invocation Structure
 
 ```typescript
 interface UCANInvocation {
@@ -78,12 +78,12 @@ interface UCANInvocation {
     /** Map of delegation CIDs to be stored */
     delegations: Record<string, CID>
   }
-  /** Array of UCAN delegations containing space/content/serve capability */
+  /** Array of UCAN delegations proving space/content/serve capability */
   proofs: Delegation[]
 }
 ```
 
-### Space Content Serve Delegation Structure
+### `space/content/serve` Delegation Structure
 
 (contained in proofs):
 

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -8,7 +8,6 @@
 
 - [Felipe Forbeck](https://github.com/fforbeck), [Storacha Network](https://storacha.network/)
 
-
 ## Abstract
 
 Content Server Authorization ensures that access to content is governed by delegations using UCANs (User Controlled Authorization Networks) and served by explicitly authorized services.
@@ -52,8 +51,6 @@ sequenceDiagram
     Gateway-->>Client: Delegation Acknowledged
 ```
 
-
-
 ## Content Retrieval Flow
 
 When a client requests content
@@ -87,8 +84,6 @@ sequenceDiagram
         Gateway-->>Client: 403 Forbidden
     end
 ```
-
-
 
 ## Considerations
 

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -37,16 +37,20 @@ sequenceDiagram
     Gateway-->>Client: Delegation Acknowledged
 ```
 
-**Flow**
-   1. Client creates a UCAN delegation granting `space/content/serve` capability to the gateway
-      - During space creation, the Storacha Client delegates the `space/content/serve` capability to the services designed to serve content from the Storacha Network to clients (for example an IPFS Gateway), by sending a `POST /access/delegate` request containing the UCAN delegation.
-      - `space/content/serve`: delegation that authorizes the service to serve data stored in a given space to any client requesting it.
-      - In the future, IPFS Gateways may support different delegation strategies such as: restricting access to specific CIDs, use of access tokens, restrictions on transport modes (http/bitswap).
-   2. Client wraps this delegation in an `access/delegate` UCAN invocation
-   3. Client encodes the invocation as CAR format and sends to `POST /`
-   4. Gateway validates the delegation chain and stores the delegation
-      - For the Storacha IPFS Gateway, the Delegations are stored using a key composed of the space DID and the delegation CID, but the implementer can use any strategy to store the delegations.
-      - Multiple delegations can exist for the same space, allowing flexibility in access control.
+### Flow
+
+1. Client creates a UCAN delegation granting `space/content/serve` capability to the gateway
+
+   - During space creation, the Storacha Client delegates the `space/content/serve` capability to the services designed to serve content from the Storacha Network to clients (for example an IPFS Gateway), by sending a `POST /access/delegate` request containing the UCAN delegation.
+   - `space/content/serve`: delegation that authorizes the service to serve data stored in a given space to any client requesting it.
+   - In the future, IPFS Gateways may support different delegation strategies such as: restricting access to specific CIDs, use of access tokens, restrictions on transport modes (http/bitswap).
+
+2. Client wraps this delegation in an `access/delegate` UCAN invocation
+3. Client encodes the invocation as CAR format and sends to `POST /`
+4. Gateway validates the delegation chain and stores the delegation
+
+   - For the Storacha IPFS Gateway, the Delegations are stored using a key composed of the space DID and the delegation CID, but the implementer can use any strategy to store the delegations.
+   - Multiple delegations can exist for the same space, allowing flexibility in access control.
 
 ## API Specification
 
@@ -57,11 +61,12 @@ POST /
 Content-Type: application/car
 ```
 
-**Request Body**
+### Request Body
 
- - CAR-encoded UCAN invocation
+- CAR-encoded UCAN invocation
 
-**UCAN Invocation Structure**
+### UCAN Invocation Structure
+
 ```typescript
 interface UCANInvocation {
   /** The capability being invoked */
@@ -78,7 +83,9 @@ interface UCANInvocation {
 }
 ```
 
-**Space Content Serve Delegation Structure** (contained in proofs):
+### Space Content Serve Delegation Structure
+(contained in proofs):
+
 ```typescript
 interface ContentServeDelegation {
   /** The capability being delegated */
@@ -90,7 +97,8 @@ interface ContentServeDelegation {
 }
 ```
 
-**Response Codes**
+### Response Codes
+
 - `200 OK`: Delegation accepted and stored
 - `400 Bad Request`: Invalid UCAN or malformed request
 - `403 Forbidden`: Unauthorized to delegate for this space

--- a/content-serve-auth.md
+++ b/content-serve-auth.md
@@ -3,6 +3,9 @@
 ## Editors
 
 - [Felipe Forbeck](https://github.com/fforbeck), [Storacha Network](https://storacha.network/)
+- [Petra Jaros](https://github.com/Peeja), [Storacha Network](https://storacha.network/)
+- [Alan Shaw](https://github.com/alanshaw), [Storacha Network](https://storacha.network/)
+- [Forrest Weston](https://github.com/frrist), [Storacha Network](https://storacha.network/)
 
 ## Authors
 
@@ -30,7 +33,7 @@ sequenceDiagram
     participant Delegations Store
 
     User->>Client: Create Space (DID)
-    Client->>Gateway: POST / (CAR-encoded UCAN)
+    Client->>Gateway: POST / (CAR-encoded access/delegate invocation)
     Gateway->>Gateway: Validate access/delegate UCAN Invocation
     Gateway->>Gateway: Extract and validate space/content/serve delegation
     Gateway->>Delegations Store: Store Delegation (Space DID + Delegation CID)
@@ -51,6 +54,8 @@ sequenceDiagram
 
    - For the Storacha IPFS Gateway, the Delegations are stored using a key composed of the space DID and the delegation CID, but the implementer can use any strategy to store the delegations.
    - Multiple delegations can exist for the same space, allowing flexibility in access control.
+
+Note: This is a standard Ucanto invocation flow.
 
 ## API Specification
 


### PR DESCRIPTION
### Description

Introduces the spec for the Content Serve Authorization Flow: [preview](https://github.com/storacha/specs/blob/6978340ae82df06bb6b38f0a877101dee0d2aaf3/content-serve-auth.md)

Closes: https://github.com/storacha/specs/issues/129