### PR TITLE
feat(w3-account): add account/egress/get capability

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -186,3 +186,4 @@ Unprocessable
 satisfiable
 CORS
 cURL
+lexicographically

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 This repository contains the specs for the `w3up` protocol and associated subsystems.
 
-The implementations of these specs can be found in <https://github.com/storacha/upload-service/packages/capabilities>
+The implementations of these specs can be found in [storacha/upload-service/packages/capabilities](https://github.com/storacha/upload-service/tree/main/packages/capabilities)
 
 ## Overview
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 This repository contains the specs for the `w3up` protocol and associated subsystems.
 
-The implementations of these specs can be found in <https://github.com/web3-storage/w3up>
+The implementations of these specs can be found in <https://github.com/storacha/upload-service/packages/capabilities>
 
 ## Overview
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,8 @@
 
 This repository contains the specs for the `w3up` protocol and associated subsystems.
 
-The implementations of these specs can be found in [storacha/upload-service/packages/capabilities](https://github.com/storacha/upload-service/tree/main/packages/capabilities)
+The implementations of these specs can be found in [upload-service/packages/capabilities](https://github.com/storacha/upload-service/tree/main/packages/capabilities) (Javascript)
+and [go-libstoracha/capabilities](https://github.com/storacha/go-libstoracha/tree/main/capabilities) (Go).
 
 ## Overview
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 This repository contains the specs for the `w3up` protocol and associated subsystems.
 
-The implementations of these specs can be found in [upload-service/packages/capabilities](https://github.com/storacha/upload-service/tree/main/packages/capabilities) (Javascript)
+The implementations of these specs can be found in [upload-service/packages/capabilities](https://github.com/storacha/upload-service/tree/main/packages/capabilities) (JavaScript)
 and [go-libstoracha/capabilities](https://github.com/storacha/go-libstoracha/tree/main/capabilities) (Go).
 
 ## Overview

--- a/w3-account.md
+++ b/w3-account.md
@@ -479,7 +479,7 @@ type DailyStat {
 }
 ```
 
-In all responses, the keys of the `spaces` field in `AccountEgressGetSuccess` MUST be sorted lexicographically. DailyStats within each SpaceEgress MUST be sorted by date ascending. This ensures that the same query produces the same output each time.
+In all responses, the keys of the `spaces` field in `AccountEgressGetSuccess` MUST be sorted lexicographically. `DailyStats` within each `SpaceEgress` MUST be sorted by date ascending. This ensures that the same query produces the same output each time.
 
 ##### Receipt example (success)
 

--- a/w3-account.md
+++ b/w3-account.md
@@ -333,7 +333,7 @@ type ISO8601Date = string
 type ProviderDID = string
 ```
 
-In all responses, the keys of the `spaces` field in `AccountUsageGetSuccess` and the `providers` field in `SpaceUsage` MUST be sorted lexicographically by their respective key (SpaceDID, ProviderDID). This ensures that the same query produces the same output each time.
+In all responses, the keys of the `spaces` field in `AccountUsageGetSuccess` and the `providers` field in `SpaceUsage` MUST be sorted lexicographically by their respective key (`SpaceDID`, `ProviderDID`). This ensures that the same query produces the same output each time.
 
 ##### Receipt example (success)
 
@@ -371,37 +371,37 @@ In all responses, the keys of the `spaces` field in `AccountUsageGetSuccess` and
 
 ## Implementations
 
-### [`w3 login <email>` in w3cli](https://github.com/web3-storage/w3cli#w3-login-email)
+### [`storacha login <email>` in CLI](https://github.com/web3-storage/w3cli#w3-login-email)
 
-- invokes [Account.login](https://github.com/web3-storage/w3cli/blob/fc97ee1b76551bced861f08a4d1e7a31440a6a14/bin.js#L56) which calls `login` on a `@web3-storage/w3up-client`
+- invokes [Account.login](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/cli/bin.js#L75) which calls `login` on a `@storacha/client`
 
-### [@web3-storage/w3up-client][]
+### [@storacha/client][]
 
-- login method [returns](https://github.com/web3-storage/w3up/blob/main/packages/w3up-client/src/account.js#L82) an `Account` instance
-  - [used](https://github.com/web3-storage/w3cli/blob/fc97ee1b76551bced861f08a4d1e7a31440a6a14/account.js#L1) by w3cli
+- login method [returns](https://github.com/storacha/w3up/blob/d02da30f51dfb79cfc9ce63f0b3a28aa9ea2345e/packages/w3up-client/src/account.js#L83) an `Account` instance
+  - [used](https://github.com/storacha/upload-service/blob/main/packages/cli/account.js) by CLI
 
 [@web3-storage/w3up-client]: https://github.com/web3-storage/w3up/tree/main/packages/w3up-client
 
-### [@ucanto/*](https://github.com/web3-storage/ucanto/tree/main)
+### [@ucanto/*](https://github.com/storacha/ucanto/tree/main)
 
 ucanto contains all kinds of tools for building application layer services aligned with the w3-account model.
 
 Examples
 
-- [@web3-storage/upload-api](https://github.com/web3-storage/w3up/tree/main/packages/upload-api) - application logic for up.web3.storage
-  - `createServer` [uses `@ucanto/server`](https://github.com/web3-storage/w3up/blob/main/packages/upload-api/src/lib.js#L29)
-  - example [invocation handler for `access/delegate`](https://github.com/web3-storage/w3up/blob/main/packages/upload-api/src/access/delegate.js#L17) using `@ucanto/types`
-- [@web3-storage/access-client](https://github.com/web3-storage/w3up/tree/main/packages/access-client) - uses `@ucanto/client` to invoke `@web3-storage/upload/api`
+- [@storacha/upload-api](https://github.com/storacha/upload-service/tree/main/packages/upload-api) - application logic for up.storacha.network
+  - `createServer` [uses `@ucanto/server`](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/upload-api/src/lib.js#L36)
+  - example [invocation handler for `access/delegate`](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/upload-api/src/access/delegate.js#L17) using `@ucanto/types`
+- [@storacha/access-client](https://github.com/storacha/upload-service/tree/main/packages/access-client) - uses `@ucanto/client` to invoke `@storacha/upload-api`
 
-### [@web3-storage/did-mailto](https://github.com/web3-storage/w3up/tree/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/did-mailto)
+### [@storacha/did-mailto](https://github.com/storacha/upload-service/tree/main/packages/did-mailto)
 
 - `fromEmail` and `toEmail` functions to encoded/decode `did:mailto` from email addresses.
-- has `import("@web3-storage/did-mailto/types").DidMailto` typescript type
+- has `import("@storacha/did-mailto/types").DidMailto` typescript type
 
 Examples
 
-- [@web3-storage/w3cli for account management cli](https://github.com/web3-storage/w3cli/blob/fc97ee1b76551bced861f08a4d1e7a31440a6a14/account.js#L3)
-- [@w3up-client](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/w3up-client/src/types.ts#L18)
+- [@storacha/cli for account management cli](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/cli/account.js#L5)
+- [@storacha/client](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/w3up-client/src/types.ts#L22)
 
 [Protocol Labs]:https://protocol.ai/
 [Irakli Gozalishvili]:https://github.com/Gozala

--- a/w3-account.md
+++ b/w3-account.md
@@ -202,7 +202,6 @@ type AccountUsage = {
 
 Capability can be invoked by an agent to retrieve usage data for all, or a specified set, of spaces within an account for a given period.
 
-
 #### Capability schema
 
 ```ipldsch
@@ -368,40 +367,6 @@ In all responses, the keys of the `spaces` field in `AccountUsageGetSuccess` and
   }
 }
 ```
-
-## Implementations
-
-### [`storacha login <email>` in CLI](https://github.com/web3-storage/w3cli#w3-login-email)
-
-- invokes [Account.login](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/cli/bin.js#L75) which calls `login` on a `@storacha/client`
-
-### [@storacha/client][]
-
-- login method [returns](https://github.com/storacha/w3up/blob/d02da30f51dfb79cfc9ce63f0b3a28aa9ea2345e/packages/w3up-client/src/account.js#L83) an `Account` instance
-  - [used](https://github.com/storacha/upload-service/blob/main/packages/cli/account.js) by CLI
-
-[@web3-storage/w3up-client]: https://github.com/web3-storage/w3up/tree/main/packages/w3up-client
-
-### [@ucanto/*](https://github.com/storacha/ucanto/tree/main)
-
-ucanto contains all kinds of tools for building application layer services aligned with the w3-account model.
-
-Examples
-
-- [@storacha/upload-api](https://github.com/storacha/upload-service/tree/main/packages/upload-api) - application logic for up.storacha.network
-  - `createServer` [uses `@ucanto/server`](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/upload-api/src/lib.js#L36)
-  - example [invocation handler for `access/delegate`](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/upload-api/src/access/delegate.js#L17) using `@ucanto/types`
-- [@storacha/access-client](https://github.com/storacha/upload-service/tree/main/packages/access-client) - uses `@ucanto/client` to invoke `@storacha/upload-api`
-
-### [@storacha/did-mailto](https://github.com/storacha/upload-service/tree/main/packages/did-mailto)
-
-- `fromEmail` and `toEmail` functions to encoded/decode `did:mailto` from email addresses.
-- has `import("@storacha/did-mailto/types").DidMailto` typescript type
-
-Examples
-
-- [@storacha/cli for account management cli](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/cli/account.js#L5)
-- [@storacha/client](https://github.com/storacha/upload-service/blob/440554db155fde9498358ecc0ae0065e647757d1/packages/w3up-client/src/types.ts#L22)
 
 [Protocol Labs]:https://protocol.ai/
 [Irakli Gozalishvili]:https://github.com/Gozala

--- a/w3-account.md
+++ b/w3-account.md
@@ -185,6 +185,190 @@ The attestation signature is denoted by a [Nonstandard `VarSig` signature] with 
 { "/": { "bytes": "gKADAA" } }
 ```
 
+## Capabilities
+
+### `account/usage/*`
+
+Capability can only be delegated (not invoked) to allow an audience to derive any `account/usage/*` prefixed capability for the account identified in the `with` field.
+
+```ts
+type AccountUsage = {
+  can: 'account/usage/*'
+  with: AccountDID
+}
+```
+
+### `account/usage/get`
+
+Capability can be invoked by an agent to retrieve usage data for all, or a specified set, of spaces within an account for a given period.
+
+
+#### Capability schema
+
+```ipldsch
+type AccountUsageGet struct {
+  with AccountDID
+  nb optional AccountUsageGetNB
+}
+
+type AccountUsageGetNB struct {
+  # Optional list of spaces to filter. If omitted, provider SHOULD aggregate all spaces the account is authorized to include.
+  spaces optional [SpaceDID]
+
+  # Optional time period (Unix timestamps in seconds).
+  # If omitted, provider MUST return a current snapshot.
+  # Semantics: from is inclusive; to is exclusive.
+  period optional Period
+}
+
+type Period struct {
+  from Int # inclusive
+  to Int   # exclusive
+}
+```
+
+#### Invocation examples
+
+> Example: getting the current total usage
+
+```json
+{
+  "iss": "did:key:z6MktfnQz8Kcz5nsC65oyXWFXhbbAZQavjg6LYuHOOOagent",
+  "aud": "did:web:storacha.network",
+  "att": [
+    {
+      "with": "did:mailto:web.mail:alice",
+      "can": "account/usage/get"
+    }
+  ],
+  "prf": [
+    { "/": "bafyAccountDelegationCid" },
+    { "/": "bafySessionAttestationCid" }
+  ],
+  "sig": "..."
+}
+```
+
+> Example: filtering a single space and period
+
+```json
+{
+  "iss": "did:key:z6MktfnQz8Kcz5nsC65oyXWFXhbbAZQavjg6LYuHOOOagent",
+  "aud": "did:web:storacha.network",
+  "att": [
+    {
+      "with": "did:mailto:web.mail:alice",
+      "can": "account/usage/get",
+      "nb": {
+        "spaces": [
+          "did:key:z6MkuxVKbEvYzXw89c9ESd3xoZ988MFrCgqT5JF5wtBvuYWe"
+        ],
+        "period": {
+          "from": 1754006400,
+          "to": 1758111728
+        }
+      }
+    }
+  ],
+  "prf": [
+    { "/": "bafyAccountDelegationCid" },
+    { "/": "bafySessionAttestationCid" }
+  ],
+  "sig": "..."
+}
+```
+
+#### Authorization requirements
+
+The service MUST verify that the Account DID is authorized to access usage data for all requested spaces. If any requested space is not authorized, the entire invocation SHOULD fail with an error message indicating which spaces lack authorization.
+
+#### Receipt
+
+```ipldsch
+type AccountUsageGetReceipt = {
+  ran: Link<AccountUsageGet>
+  out: Result<AccountUsageGetSuccess, AccountUsageGetFailure>
+}
+
+type AccountUsageGetFailure {
+  message: string
+}
+
+type AccountUsageGetSuccess {
+  total  Int
+  spaces Record<SpaceDID, SpaceUsage>   # keys MUST be sorted
+}
+
+type SpaceUsage {
+  total     Int
+  providers Record<ProviderDID, UsageData>  # keys MUST be sorted
+}
+
+# UsageData is shared with `usage/report`
+type UsageData {
+  provider ProviderDID
+  space    SpaceDID
+  period   PeriodISO
+  size     SizeDelta
+  events   optional [UsageEvent]
+}
+
+type SizeDelta {
+  initial Int
+  final   Int
+}
+
+type UsageEvent {
+  cause     Link
+  delta     Int
+  receiptAt ISO8601Date
+}
+
+type PeriodISO {
+  from ISO8601Date
+  to   ISO8601Date
+}
+
+type ISO8601Date = string
+type ProviderDID = string
+```
+
+In all responses, the keys of the `spaces` field in `AccountUsageGetSuccess` and the `providers` field in `SpaceUsage` MUST be sorted lexicographically by their respective key (SpaceDID, ProviderDID). This ensures that the same query produces the same output each time.
+
+##### Receipt example (success)
+
+```json
+{
+  "total": 5356848797,
+  "spaces": {
+    "did:key:z6MkuxVKbEvYzXw89c9ESd3xoZ988MFrCgqT5JF5wtBvuYWe": {
+      "total": 5356848797,
+      "providers": {
+        "did:web:web3.storage": {
+          "provider": "did:web:web3.storage",
+          "space": "did:key:z6MkuxVKbEvYzXw89c9ESd3xoZ988MFrCgqT5JF5wtBvuYWe",
+          "period": {
+            "from": "2025-07-01T00:00:00.000Z",
+            "to": "2025-08-12T15:55:11.000Z"
+          },
+          "size": {
+            "initial": 1035217049,
+            "final": 5356848797
+          },
+          "events": [
+            {
+              "cause": { "/": "bafyreiafouslzry3vunc4okazrqpwpuanrq4d3ehb2oatn4vmrhnmj6rzy" },
+              "delta": 54394,
+              "receiptAt": "2025-07-01T14:34:50.947Z"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
 ## Implementations
 
 ### [`w3 login <email>` in w3cli](https://github.com/web3-storage/w3cli#w3-login-email)

--- a/w3-account.md
+++ b/w3-account.md
@@ -224,7 +224,7 @@ type AccountUsageGetNB struct {
 
 type Period struct {
   from Int # inclusive
-  to Int   # exclusive
+  to   Int # exclusive
 }
 ```
 
@@ -286,27 +286,27 @@ The service MUST verify that the Account DID is authorized to access usage data 
 #### Receipt
 
 ```ipldsch
-type AccountUsageGetReceipt = {
+type AccountUsageGetReceipt struct {
   ran Link<AccountUsageGet>
   out Result<AccountUsageGetSuccess, AccountUsageGetFailure>
 }
 
-type AccountUsageGetFailure {
+type AccountUsageGetFailure struct {
   message String
 }
 
-type AccountUsageGetSuccess {
+type AccountUsageGetSuccess struct {
   total  Int
-  spaces Record<SpaceDID, SpaceUsage>   # keys MUST be sorted
+  spaces {SpaceDID: SpaceUsage} # keys MUST be sorted
 }
 
-type SpaceUsage {
+type SpaceUsage struct {
   total     Int
-  providers Record<ProviderDID, UsageData>  # keys MUST be sorted
+  providers {ProviderDID: UsageData} # keys MUST be sorted
 }
 
 # UsageData is shared with `usage/report`
-type UsageData {
+type UsageData struct {
   provider ProviderDID
   space    SpaceDID
   period   PeriodISO
@@ -314,18 +314,18 @@ type UsageData {
   events   [UsageEvent]
 }
 
-type SizeDelta {
+type SizeDelta struct {
   initial Int
   final   Int
 }
 
-type UsageEvent {
+type UsageEvent struct {
   cause     Link
   delta     Int
   receiptAt ISO8601Date
 }
 
-type PeriodISO {
+type PeriodISO struct {
   from ISO8601Date
   to   ISO8601Date
 }
@@ -454,27 +454,27 @@ The service MUST verify that the Account DID is authorized to access egress data
 #### Receipt
 
 ```ipldsch
-type AccountEgressGetReceipt = {
+type AccountEgressGetReceipt struct {
   ran Link<AccountEgressGet>
   out Result<AccountEgressGetSuccess, AccountEgressGetFailure>
 }
 
-type AccountEgressGetFailure {
+type AccountEgressGetFailure struct {
   name    String
   message String
 }
 
-type AccountEgressGetSuccess {
+type AccountEgressGetSuccess struct {
   total  Int # total egress for the account in the requested period. Unit: bytes.
-  spaces Record<SpaceDID, SpaceEgress> # breakout per-space. Keys MUST be sorted.
+  spaces {SpaceDID: SpaceEgress} # breakout per-space. Keys MUST be sorted.
 }
 
-type SpaceEgress {
+type SpaceEgress struct {
   total      Int # total egress for the space in the requested period. Unit: bytes.
   dailyStats [DailyStat] # sorted by date ascending
 }
 
-type DailyStat {
+type DailyStat struct {
   date   ISO8601Date
   egress Int # egress for that date. Unit: bytes.
 }

--- a/w3-account.md
+++ b/w3-account.md
@@ -9,6 +9,8 @@
 ## Authors
 
 - [Irakli Gozalishvili], [Protocol Labs]
+- [Natalie Bravo], [Storacha Network]
+- [Vicente Olmedo], [Storacha Network]
 
 # Abstract
 
@@ -50,13 +52,13 @@ Agent authorization can use familiar email-based authorization flows providing a
 
 There are several distinct roles that [principals] may assume in described specification:
 
-| Name        | Description                                                                                                                                    |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Principal | The general class of entities that interact with a UCAN. Listed in the `iss` or `aud` field |
-| Account    | [Principal] identified by memorable identifier like [`did:mailto`]. |
-| Agent       | [Principal] identified by [`did:key`] identifier, representing a user in some application installation |
-| Issuer | Principal sharing access. It is the signer of the [UCAN]. Listed in the `iss` field |
-| Audience | Principal access is shared with. Listed in the `aud` field |
+| Name      | Description                                                                                            |
+| --------- | ------------------------------------------------------------------------------------------------------ |
+| Principal | The general class of entities that interact with a UCAN. Listed in the `iss` or `aud` field            |
+| Account   | [Principal] identified by memorable identifier like [`did:mailto`].                                    |
+| Agent     | [Principal] identified by [`did:key`] identifier, representing a user in some application installation |
+| Issuer    | Principal sharing access. It is the signer of the [UCAN]. Listed in the `iss` field                    |
+| Audience  | Principal access is shared with. Listed in the `aud` field                                             |
 
 ### Space
 
@@ -285,12 +287,12 @@ The service MUST verify that the Account DID is authorized to access usage data 
 
 ```ipldsch
 type AccountUsageGetReceipt = {
-  ran: Link<AccountUsageGet>
-  out: Result<AccountUsageGetSuccess, AccountUsageGetFailure>
+  ran Link<AccountUsageGet>
+  out Result<AccountUsageGetSuccess, AccountUsageGetFailure>
 }
 
 type AccountUsageGetFailure {
-  message: string
+  message String
 }
 
 type AccountUsageGetSuccess {
@@ -328,8 +330,8 @@ type PeriodISO {
   to   ISO8601Date
 }
 
-type ISO8601Date = string
-type ProviderDID = string
+type ISO8601Date string
+type ProviderDID string
 ```
 
 In all responses, the keys of the `spaces` field in `AccountUsageGetSuccess` and the `providers` field in `SpaceUsage` MUST be sorted lexicographically by their respective key (`SpaceDID`, `ProviderDID`). This ensures that the same query produces the same output each time.
@@ -368,33 +370,174 @@ In all responses, the keys of the `spaces` field in `AccountUsageGetSuccess` and
 }
 ```
 
-[Protocol Labs]:https://protocol.ai/
-[Irakli Gozalishvili]:https://github.com/Gozala
-[PKI]:https://en.wikipedia.org/wiki/Public_key_infrastructure
-[UCAN]:https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md
-[`did:mailto`]:./did-mailto.md
-[`did:key`]:https://w3c-ccg.github.io/did-key-spec/
-[principal]:https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md#321-principals
+### `account/egress/get`
+
+Capability can be invoked by an agent to retrieve egress data for all, or a specified set, of spaces within an account for a given period.
+
+#### Capability schema
+
+```ipldsch
+type AccountEgressGet struct {
+  with AccountDID
+  nb optional AccountEgressGetNB
+}
+
+type AccountEgressGetNB struct {
+  # Optional list of spaces to filter. If omitted, provider SHOULD aggregate all spaces the account is authorized to include.
+  spaces optional [SpaceDID]
+
+  # Optional time period
+  # If omitted, provider MUST return egress data from the first day of the last full month to the day the request is made.
+  period optional Period
+}
+
+# From and to are both inclusive and expressed as ISO-8601 date-only strings (e.g. 2026-01-20).
+type Period struct {
+  from ISO8601Date
+  to ISO8601Date
+}
+
+type ISO8601Date string
+```
+
+#### Invocation examples
+
+> Example: getting the current total egress
+
+```json
+{
+  "iss": "did:key:z6MktfnQz8Kcz5nsC65oyXWFXhbbAZQavjg6LYuHOOOagent",
+  "aud": "did:web:etracker.storacha.network",
+  "att": [
+    {
+      "with": "did:mailto:web.mail:alice",
+      "can": "account/egress/get"
+    }
+  ],
+  "prf": [
+    { "/": "bafyAccountDelegationCid" },
+    { "/": "bafySessionAttestationCid" },
+  ],
+  "sig": "..."
+}
+```
+
+> Example: filtering a single space and period
+
+```json
+{
+  "iss": "did:key:z6MktfnQz8Kcz5nsC65oyXWFXhbbAZQavjg6LYuHOOOagent",
+  "aud": "did:web:etracker.storacha.network",
+  "att": [
+    {
+      "with": "did:mailto:web.mail:alice",
+      "can": "account/egress/get",
+      "nb": {
+        "spaces": ["did:key:z6MkuxVKbEvYzXw89c9ESd3xoZ988MFrCgqT5JF5wtBvuYWe"],
+        "period": {
+          "from": "2025-07-01",
+          "to": "2025-07-02"
+        }
+      }
+    }
+  ],
+  "prf": [{ "/": "bafyAccountDelegationCid" }, { "/": "bafySessionAttestationCid" }],
+  "sig": "..."
+}
+```
+
+#### Authorization requirements
+
+The service MUST verify that the Account DID is authorized to access egress data for all requested spaces. If any of the requested spaces is not authorized, the entire invocation SHOULD fail with an error message indicating which spaces lack authorization.
+
+#### Receipt
+
+```ipldsch
+type AccountEgressGetReceipt = {
+  ran Link<AccountEgressGet>
+  out Result<AccountEgressGetSuccess, AccountEgressGetFailure>
+}
+
+type AccountEgressGetFailure {
+  name    String
+  message String
+}
+
+type AccountEgressGetSuccess {
+  total  Int # total egress for the account in the requested period. Unit: bytes.
+  spaces Record<SpaceDID, SpaceEgress> # breakout per-space. Keys MUST be sorted.
+}
+
+type SpaceEgress {
+  total      Int # total egress for the space in the requested period. Unit: bytes.
+  dailyStats [DailyStat] # sorted by date ascending
+}
+
+type DailyStat {
+  date   ISO8601Date
+  egress Int # egress for that date. Unit: bytes.
+}
+```
+
+In all responses, the keys of the `spaces` field in `AccountEgressGetSuccess` MUST be sorted lexicographically. DailyStats within each SpaceEgress MUST be sorted by date ascending. This ensures that the same query produces the same output each time.
+
+##### Receipt example (success)
+
+```json
+{
+  "total": 1111111110,
+  "spaces": {
+    "did:key:z6MkuxVKbEvYzXw89c9ESd3xoZ988MFrCgqT5JF5wtBvuYWe": {
+      "total": 1111111110,
+      "dailyStats": [
+        {
+          "date": "2025-07-01",
+          "egress": 123456789
+        },
+        {
+          "date": "2025-07-02",
+          "egress": 987654321
+        }
+      ]
+    }
+  }
+}
+```
+
+[Protocol Labs]: https://protocol.ai/
+[Irakli Gozalishvili]: https://github.com/Gozala
+[Natalie Bravo]: https://github.com/bravonatalie
+[Vicente Olmedo]: https://github.com/volmedo
+[Storacha Network]: https://storacha.network/
+[PKI]: https://en.wikipedia.org/wiki/Public_key_infrastructure
+[UCAN]: https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md
+[`did:mailto`]: ./did-mailto.md
+[`did:key`]: https://w3c-ccg.github.io/did-key-spec/
+[principal]: https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md#321-principals
+
 <!-- markdown-link-check-disable -->
 <!-- stackexchange 403s this, presumably to prevent bot scraping -->
-[non-extractable keys]:https://crypto.stackexchange.com/questions/85587/what-do-people-use-non-extractable-webcrypto-keys-for/102695#102695
+
+[non-extractable keys]: https://crypto.stackexchange.com/questions/85587/what-do-people-use-non-extractable-webcrypto-keys-for/102695#102695
+
 <!-- markdown-link-check-enable-->
-[agent]:#agent
-[account]:#account
-[UCAN-IPLD Schema]:https://github.com/ucan-wg/ucan-ipld/#2-ipld-schema
-[link]:https://ipld.io/docs/schemas/features/links/
-[authorization payload]:#authorization-payload
-[RFC6376]:https://www.rfc-editor.org/rfc/rfc6376#section-3.4
-[Nonstandard `VarSig` signature]:https://github.com/ucan-wg/ucan-ipld/#251-nonstandard-signatures
-[ABNF]:https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form
-[DAG-JSON]:https://ipld.io/specs/codecs/dag-json/spec/
-[ucan attestation]:./w3-ucan.md#attestation
+
+[agent]: #agent
+[account]: #account
+[UCAN-IPLD Schema]: https://github.com/ucan-wg/ucan-ipld/#2-ipld-schema
+[link]: https://ipld.io/docs/schemas/features/links/
+[authorization payload]: #authorization-payload
+[RFC6376]: https://www.rfc-editor.org/rfc/rfc6376#section-3.4
+[Nonstandard `VarSig` signature]: https://github.com/ucan-wg/ucan-ipld/#251-nonstandard-signatures
+[ABNF]: https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form
+[DAG-JSON]: https://ipld.io/specs/codecs/dag-json/spec/
+[ucan attestation]: ./w3-ucan.md#attestation
 [IPLD]: https://ipld.io/
 [DAG-CBOR]: https://ipld.io/specs/codecs/dag-cbor/spec/
-[DID methods]:https://www.w3.org/TR/did-core/#methods
-[w3up]:https://github.com/web3-storage/w3up
-[owner]:#owner
-[space]:#space
-[DKIM]:https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
-[attestation]:./w3-ucan.md#attestation
-[authority]:#authority
+[DID methods]: https://www.w3.org/TR/did-core/#methods
+[w3up]: https://github.com/web3-storage/w3up
+[owner]: #owner
+[space]: #space
+[DKIM]: https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail
+[attestation]: ./w3-ucan.md#attestation
+[authority]: #authority

--- a/w3-account.md
+++ b/w3-account.md
@@ -391,7 +391,8 @@ type AccountEgressGetNB struct {
   period optional Period
 }
 
-# From and to are both inclusive and expressed as ISO-8601 date-only strings (e.g. 2026-01-20).
+# From and to are both expressed as ISO-8601 date-only strings (e.g. 2026-01-20).
+# From is inclusive; to is exclusive.
 type Period struct {
   from ISO8601Date
   to ISO8601Date
@@ -436,7 +437,7 @@ type ISO8601Date string
         "spaces": ["did:key:z6MkuxVKbEvYzXw89c9ESd3xoZ988MFrCgqT5JF5wtBvuYWe"],
         "period": {
           "from": "2025-07-01",
-          "to": "2025-07-02"
+          "to": "2025-07-03"
         }
       }
     }


### PR DESCRIPTION
Ref. https://github.com/storacha/project-tracking/issues/619

📚 [Preview](https://github.com/storacha/specs/blob/8947e4034ec492ce95c6b42df393d625677d7ede/w3-account.md#accountegressget)

Add the `account/egress/get` capability specification. The first use of this capability will be in Storacha Forge's customer dashboard, described in https://github.com/storacha/RFC/blob/cce367c20afaf9f8f8be799b0da5061e0bdd4898/rfc/billing-dashboard.md#customer-dashboard.

Implemented in https://github.com/storacha/go-libstoracha/pull/77 and https://github.com/storacha/upload-service/pull/638.